### PR TITLE
feat(medical-record): convert initial medical record into modal form

### DIFF
--- a/mds-frontend/src/App.jsx
+++ b/mds-frontend/src/App.jsx
@@ -6,7 +6,6 @@ import Auth from './pages/Auth.jsx';
 import { BannerProvider, useBanner } from './context/banner-context.jsx';
 import Banner from './components/banner/banner.jsx';
 import ResetPassword from './modules/auth/resetpassword.jsx';
-import InitialMedicalRecordForm from './modules/record-forms/initial-record/medical/initial-medical-record-form.jsx';
 
 function AppContent() {
   const { showBanner } = useBanner();
@@ -39,14 +38,10 @@ function AppContent() {
           <Route path="/auth/login" element={<Auth />} />
           <Route path="/auth/register" element={<Auth />} />
           
-          {/* Initial Medical Record */}
+          {/* Initial Medical Record - Now redirects to dashboard where modal appears */}
           <Route 
             path="/initial-medical-record" 
-            element={
-              <PrivateRoute>
-                <InitialMedicalRecordForm />
-              </PrivateRoute>
-            } 
+            element={<Navigate to="/" replace />}
           />
 
           {/* Redirect any unknown routes to root */}

--- a/mds-frontend/src/components/modals/initial-record-modal.jsx
+++ b/mds-frontend/src/components/modals/initial-record-modal.jsx
@@ -1,0 +1,102 @@
+import React, { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+
+/**
+ * Modal overlay for Initial Medical Record
+ * Shows as an overlay on top of the dashboard with blur effect
+ * This modal cannot be closed/dismissed - user must complete the form
+ */
+const InitialRecordModal = ({ 
+  isOpen, 
+  children,
+  onComplete
+}) => {
+  const modalRef = useRef(null);
+
+  // Prevent body scroll when modal is open
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    }
+
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, [isOpen]);
+
+  // Prevent ESC key from closing the modal
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape' && isOpen) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleKeyDown, true);
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown, true);
+    };
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const modalContent = (
+    <div 
+      className="fixed inset-0 z-[9999] flex items-start justify-center overflow-y-auto py-4 px-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="initial-record-modal-title"
+      style={{ 
+        backgroundColor: 'rgba(0, 0, 0, 0.6)',
+        backdropFilter: 'blur(8px)',
+        WebkitBackdropFilter: 'blur(8px)'
+      }}
+    >
+      <div 
+        ref={modalRef}
+        className="relative w-full max-w-5xl bg-white dark:bg-neutral-900 rounded-2xl shadow-2xl my-4 animate-slide-in"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header Banner */}
+        <div className="sticky top-0 z-10 bg-gradient-to-r from-primary-600 to-primary-700 text-white px-6 py-4 rounded-t-2xl">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-white/20 rounded-lg">
+                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                </svg>
+              </div>
+              <div>
+                <h1 id="initial-record-modal-title" className="text-xl font-bold">
+                  Complete Your Medical Record
+                </h1>
+                <p className="text-sm text-white/80">
+                  Please fill out your initial medical record to access the dashboard
+                </p>
+              </div>
+            </div>
+            <div className="hidden sm:flex items-center gap-2 text-sm bg-white/20 px-4 py-2 rounded-full">
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+              </svg>
+              <span>Required for Access</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="max-h-[calc(100vh-120px)] overflow-y-auto">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(modalContent, document.body);
+};
+
+export default InitialRecordModal;

--- a/mds-frontend/src/modules/auth/login/login.jsx
+++ b/mds-frontend/src/modules/auth/login/login.jsx
@@ -173,15 +173,8 @@ const Login = () => {
           TokenStorage.setTokens(response.data.accessToken, response.data.refreshToken);
         }
         
-        // Check if user has completed initial medical record
-        // TODO: Query the backend to check if user has filled EMR
-        const hasCompletedMedicalRecord = false;
-        
-        if (hasCompletedMedicalRecord) {
-          navigate('/');
-        } else {
-          navigate('/initial-medical-record');
-        }
+        // Always navigate to dashboard - the dashboard will show the initial record modal if needed
+        navigate('/');
       }
     } catch (err) {
       const errorMsg = err.response?.data?.message || 'Login completion failed.';

--- a/mds-frontend/src/modules/record-forms/initial-record/medical/dental-history.jsx
+++ b/mds-frontend/src/modules/record-forms/initial-record/medical/dental-history.jsx
@@ -52,8 +52,8 @@ const DentalHistoryForm = ({ data, onChange }) => {
               <input
                 type="radio"
                 name="firstTimeDentist"
-                value="Yes"
-                checked={data.firstTimeDentist === 'Yes'}
+                value="yes"
+                checked={data.firstTimeDentist === 'yes'}
                 onChange={(e) => handleChange('firstTimeDentist', e.target.value)}
                 className="form-checkbox"
               />
@@ -63,29 +63,18 @@ const DentalHistoryForm = ({ data, onChange }) => {
               <input
                 type="radio"
                 name="firstTimeDentist"
-                value="No"
-                checked={data.firstTimeDentist === 'No'}
+                value="no"
+                checked={data.firstTimeDentist === 'no'}
                 onChange={(e) => handleChange('firstTimeDentist', e.target.value)}
                 className="form-checkbox"
               />
               <span className="ml-2 text-secondary-700">No</span>
             </label>
-            <label className="flex items-center">
-              <input
-                type="radio"
-                name="firstTimeDentist"
-                value="I don't know"
-                checked={data.firstTimeDentist === "I don't know"}
-                onChange={(e) => handleChange('firstTimeDentist', e.target.value)}
-                className="form-checkbox"
-              />
-              <span className="ml-2 text-secondary-700">I don't know</span>
-            </label>
           </div>
         </div>
 
         {/* Last Dental Consultation */}
-        {data.firstTimeDentist === 'No' && (
+        {data.firstTimeDentist === 'no' && (
           <div>
             <label className="form-label">IF "NO"... WHEN WAS YOUR LAST DENTAL CONSULTATION ?</label>
             <p className="text-xs text-secondary-500 mb-2">Indicate Month and Year</p>
@@ -149,8 +138,8 @@ const DentalHistoryForm = ({ data, onChange }) => {
               <input
                 type="radio"
                 name="hasIntraOralAppliance"
-                value="Yes"
-                checked={data.hasIntraOralAppliance === 'Yes'}
+                value="yes"
+                checked={data.hasIntraOralAppliance === 'yes'}
                 onChange={(e) => handleChange('hasIntraOralAppliance', e.target.value)}
                 className="form-checkbox"
               />
@@ -160,8 +149,8 @@ const DentalHistoryForm = ({ data, onChange }) => {
               <input
                 type="radio"
                 name="hasIntraOralAppliance"
-                value="No"
-                checked={data.hasIntraOralAppliance === 'No'}
+                value="no"
+                checked={data.hasIntraOralAppliance === 'no'}
                 onChange={(e) => handleChange('hasIntraOralAppliance', e.target.value)}
                 className="form-checkbox"
               />
@@ -171,10 +160,10 @@ const DentalHistoryForm = ({ data, onChange }) => {
         </div>
 
         {/* Appliance Types */}
-        {data.hasIntraOralAppliance === 'Yes' && (
+        {data.hasIntraOralAppliance === 'yes' && (
           <div>
             <label className="form-label mb-3">IF YES, KINDLY CHECK BELOW</label>
-            <div className="space-y-2 ml-6">
+            <div className="space-y-3 ml-6">
               <Checkbox
                 label="Dental Brace (Orthodontic appliance)"
                 checked={data.intraOralAppliances?.dentalBrace || false}
@@ -185,11 +174,53 @@ const DentalHistoryForm = ({ data, onChange }) => {
                 checked={data.intraOralAppliances?.dentalBridge || false}
                 onChange={(e) => handleApplianceChange('dentalBridge', e.target.checked)}
               />
-              <Checkbox
-                label="Dentures"
-                checked={data.intraOralAppliances?.dentures || false}
-                onChange={(e) => handleApplianceChange('dentures', e.target.checked)}
-              />
+              
+              {/* Dentures with inline location selection */}
+              <div className="flex flex-col gap-2">
+                <Checkbox
+                  label="Dentures"
+                  checked={data.intraOralAppliances?.dentures || false}
+                  onChange={(e) => handleApplianceChange('dentures', e.target.checked)}
+                />
+                {data.intraOralAppliances?.dentures && (
+                  <div className="ml-6 flex gap-4">
+                    <label className="flex items-center">
+                      <input
+                        type="radio"
+                        name="dentureLocation"
+                        value="Upper"
+                        checked={data.dentureLocation === 'Upper'}
+                        onChange={(e) => handleChange('dentureLocation', e.target.value)}
+                        className="form-checkbox"
+                      />
+                      <span className="ml-2 text-secondary-700">Upper</span>
+                    </label>
+                    <label className="flex items-center">
+                      <input
+                        type="radio"
+                        name="dentureLocation"
+                        value="Lower"
+                        checked={data.dentureLocation === 'Lower'}
+                        onChange={(e) => handleChange('dentureLocation', e.target.value)}
+                        className="form-checkbox"
+                      />
+                      <span className="ml-2 text-secondary-700">Lower</span>
+                    </label>
+                    <label className="flex items-center">
+                      <input
+                        type="radio"
+                        name="dentureLocation"
+                        value="Both"
+                        checked={data.dentureLocation === 'Both'}
+                        onChange={(e) => handleChange('dentureLocation', e.target.value)}
+                        className="form-checkbox"
+                      />
+                      <span className="ml-2 text-secondary-700">Both</span>
+                    </label>
+                  </div>
+                )}
+              </div>
+              
               <Checkbox
                 label="Bite planes, Expander, Night guards"
                 checked={data.intraOralAppliances?.bitePlanes || false}
@@ -217,42 +248,42 @@ const DentalHistoryForm = ({ data, onChange }) => {
               </div>
             </div>
 
-            {/* Appliance Location */}
+            {/* Appliance Location - for non-denture appliances */}
             <div className="mt-6">
-              <label className="form-label mb-3">SPECIFY THE LOCATION OF YOUR INTRA-ORAL APPLIANCE</label>
-              <div className="space-y-2 ml-6">
+              <label className="form-label mb-3">SPECIFY THE LOCATION OF YOUR INTRA-ORAL APPLIANCE (except dentures)</label>
+              <div className="flex gap-6 ml-6">
                 <label className="flex items-center">
                   <input
                     type="radio"
                     name="applianceLocation"
-                    value="Upper only"
-                    checked={data.applianceLocation === 'Upper only'}
+                    value="Upper"
+                    checked={data.applianceLocation === 'Upper'}
                     onChange={(e) => handleChange('applianceLocation', e.target.value)}
                     className="form-checkbox"
                   />
-                  <span className="ml-2 text-secondary-700">Upper only</span>
+                  <span className="ml-2 text-secondary-700">Upper</span>
                 </label>
                 <label className="flex items-center">
                   <input
                     type="radio"
                     name="applianceLocation"
-                    value="Lower only"
-                    checked={data.applianceLocation === 'Lower only'}
+                    value="Lower"
+                    checked={data.applianceLocation === 'Lower'}
                     onChange={(e) => handleChange('applianceLocation', e.target.value)}
                     className="form-checkbox"
                   />
-                  <span className="ml-2 text-secondary-700">Lower only</span>
+                  <span className="ml-2 text-secondary-700">Lower</span>
                 </label>
                 <label className="flex items-center">
                   <input
                     type="radio"
                     name="applianceLocation"
-                    value="Both Upper and Lower"
-                    checked={data.applianceLocation === 'Both Upper and Lower'}
+                    value="Both"
+                    checked={data.applianceLocation === 'Both'}
                     onChange={(e) => handleChange('applianceLocation', e.target.value)}
                     className="form-checkbox"
                   />
-                  <span className="ml-2 text-secondary-700">Both Upper and Lower</span>
+                  <span className="ml-2 text-secondary-700">Both</span>
                 </label>
               </div>
             </div>
@@ -269,8 +300,8 @@ const DentalHistoryForm = ({ data, onChange }) => {
               <input
                 type="radio"
                 name="toothExtraction"
-                value="Yes"
-                checked={data.toothExtraction === 'Yes'}
+                value="yes"
+                checked={data.toothExtraction === 'yes'}
                 onChange={(e) => handleChange('toothExtraction', e.target.value)}
                 className="form-checkbox"
               />
@@ -280,8 +311,8 @@ const DentalHistoryForm = ({ data, onChange }) => {
               <input
                 type="radio"
                 name="toothExtraction"
-                value="No"
-                checked={data.toothExtraction === 'No'}
+                value="no"
+                checked={data.toothExtraction === 'no'}
                 onChange={(e) => handleChange('toothExtraction', e.target.value)}
                 className="form-checkbox"
               />
@@ -300,8 +331,8 @@ const DentalHistoryForm = ({ data, onChange }) => {
               <input
                 type="radio"
                 name="dentalFilling"
-                value="Yes"
-                checked={data.dentalFilling === 'Yes'}
+                value="yes"
+                checked={data.dentalFilling === 'yes'}
                 onChange={(e) => handleChange('dentalFilling', e.target.value)}
                 className="form-checkbox"
               />
@@ -311,8 +342,8 @@ const DentalHistoryForm = ({ data, onChange }) => {
               <input
                 type="radio"
                 name="dentalFilling"
-                value="No"
-                checked={data.dentalFilling === 'No'}
+                value="no"
+                checked={data.dentalFilling === 'no'}
                 onChange={(e) => handleChange('dentalFilling', e.target.value)}
                 className="form-checkbox"
               />

--- a/mds-frontend/src/modules/record-forms/initial-record/medical/initial-medical-record-form.jsx
+++ b/mds-frontend/src/modules/record-forms/initial-record/medical/initial-medical-record-form.jsx
@@ -8,11 +8,15 @@ import DentalHistoryForm from './dental-history';
 import OBGYNEForm from './obygyne';
 import ReviewForm from './review-form';
 import { Button } from './form-elements';
+import { createInitialMedicalRecord } from '../../../../services/emr-service';
+import { validateFormData, sanitizeFormData, logDataStructure } from '../../../../utils/data-transformer';
 
 const InitialMedicalRecordForm = () => {
   const navigate = useNavigate();
   const [currentStep, setCurrentStep] = useState(0);
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  console.log('[Initial Medical Record Form] Component rendered, current step:', currentStep);
 
   const steps = ['Personal Info', 'Medical History', 'Medical Background', 'Dental History', 'OB-GYNE', 'Review'];
 
@@ -94,26 +98,32 @@ const InitialMedicalRecordForm = () => {
   });
 
   const handlePersonalInfoChange = (data) => {
+    console.log('[Initial Medical Record Form] Personal info updated:', data);
     setFormData({ ...formData, personalInfo: data });
   };
 
   const handleMedicalHistoryChange = (data) => {
+    console.log('[Initial Medical Record Form] Medical history updated:', data);
     setFormData({ ...formData, medicalHistory: data });
   };
 
   const handleMedicalBackgroundChange = (data) => {
+    console.log('[Initial Medical Record Form] Medical background updated:', data);
     setFormData({ ...formData, medicalBackground: data });
   };
 
   const handleDentalHistoryChange = (data) => {
+    console.log('[Initial Medical Record Form] Dental history updated:', data);
     setFormData({ ...formData, dentalHistory: data });
   };
 
   const handleOBGYNEChange = (data) => {
+    console.log('[Initial Medical Record Form] OB-GYNE updated:', data);
     setFormData({ ...formData, obgyne: data });
   };
 
   const handleCertificationChange = (data) => {
+    console.log('[Initial Medical Record Form] Certification updated:', data);
     setFormData({ ...formData, certification: data });
   };
 
@@ -123,9 +133,12 @@ const InitialMedicalRecordForm = () => {
   };
 
   const handleNext = () => {
+    console.log('[Initial Medical Record Form] Next button clicked, moving from step', currentStep);
+    
     if (validateStep(currentStep)) {
       // Skip OB-GYNE step if gender is not Female
       if (currentStep === 3 && formData.personalInfo.gender !== 'Female') {
+        console.log('[Initial Medical Record Form] Skipping OB-GYNE step (not female)');
         setCurrentStep(5); // Skip to Review
       } else {
         setCurrentStep(currentStep + 1);
@@ -134,8 +147,11 @@ const InitialMedicalRecordForm = () => {
   };
 
   const handleBack = () => {
+    console.log('[Initial Medical Record Form] Back button clicked, moving from step', currentStep);
+    
     // Skip OB-GYNE step when going back if gender is not Female
     if (currentStep === 5 && formData.personalInfo.gender !== 'Female') {
+      console.log('[Initial Medical Record Form] Skipping OB-GYNE step when going back (not female)');
       setCurrentStep(3); // Go back to Dental History
     } else {
       setCurrentStep(currentStep - 1);
@@ -143,27 +159,125 @@ const InitialMedicalRecordForm = () => {
   };
 
   const handleEdit = (stepIndex) => {
+    console.log('[Initial Medical Record Form] Edit requested for step:', stepIndex);
     setCurrentStep(stepIndex);
   };
 
   const handleSubmit = async () => {
+    console.log('[Initial Medical Record Form] Submit button clicked');
+    console.log('[Initial Medical Record Form] Form data:', formData);
+    
     setIsSubmitting(true);
     
     try {
-      // Static form - just log data and redirect
-      console.log('Form Data (Static):', formData);
+      console.log('[Initial Medical Record Form] Validating form data...');
       
-      // Simulate submission
-      await new Promise(resolve => setTimeout(resolve, 1000));
+      // Log the complete data structure for debugging
+      logDataStructure(formData, 'Raw Form Data');
       
-      alert('Form submitted! (Static - no backend connection)');
+      // Sanitize the data
+      const sanitizedData = sanitizeFormData(formData);
+      logDataStructure(sanitizedData, 'Sanitized Form Data');
+      
+      // Validate the data
+      const validation = validateFormData(sanitizedData);
+      
+      if (!validation.isValid) {
+        console.error('[Initial Medical Record Form] Validation failed:', validation.errors);
+        alert('Please fill in all required fields:\n\n' + validation.errors.join('\n'));
+        return;
+      }
+      
+      if (validation.warnings.length > 0) {
+        console.warn('[Initial Medical Record Form] Validation warnings:', validation.warnings);
+      }
+      
+      // Additional required field checks
+      const errors = [];
+      
+      if (!sanitizedData.personalInfo.surname) errors.push('Surname is required');
+      if (!sanitizedData.personalInfo.firstName) errors.push('First name is required');
+      if (!sanitizedData.personalInfo.birthday) errors.push('Birthday is required');
+      if (!sanitizedData.personalInfo.gender) errors.push('Gender is required');
+      if (!sanitizedData.personalInfo.contactNumber) errors.push('Contact number is required');
+      
+      if (!sanitizedData.personalInfo.emergencyContacts[0]?.name) {
+        errors.push('First emergency contact name is required');
+      }
+      if (!sanitizedData.personalInfo.emergencyContacts[0]?.relationship) {
+        errors.push('First emergency contact relationship is required');
+      }
+      if (!sanitizedData.personalInfo.emergencyContacts[0]?.contactNumber) {
+        errors.push('First emergency contact number is required');
+      }
+      
+      if (!sanitizedData.personalInfo.emergencyContacts[1]?.name) {
+        errors.push('Second emergency contact name is required');
+      }
+      if (!sanitizedData.personalInfo.emergencyContacts[1]?.relationship) {
+        errors.push('Second emergency contact relationship is required');
+      }
+      if (!sanitizedData.personalInfo.emergencyContacts[1]?.contactNumber) {
+        errors.push('Second emergency contact number is required');
+      }
+      
+      if (!sanitizedData.certification.verified) {
+        errors.push('You must verify the certification to submit');
+      }
+      
+      if (errors.length > 0) {
+        console.error('[Initial Medical Record Form] Field validation errors:', errors);
+        alert('Please fill in all required fields:\n\n' + errors.join('\n'));
+        return;
+      }
+      
+      console.log('[Initial Medical Record Form] All validations passed');
+      console.log('[Initial Medical Record Form] Submitting to backend...');
+      
+      // Submit to backend via GraphQL service
+      const result = await createInitialMedicalRecord(sanitizedData);
+      
+      console.log('[Initial Medical Record Form] Submission successful!', result);
+      
+      alert('Medical record submitted successfully! You can now access the system.');
+      
       // Navigate to dashboard
       navigate('/dashboard');
+      
     } catch (error) {
-      console.error('Error:', error);
-      alert('Something went wrong.');
+      console.error('[Initial Medical Record Form] Submission error:', error);
+      console.error('[Initial Medical Record Form] Error stack:', error.stack);
+      console.error('[Initial Medical Record Form] Error details:', {
+        message: error.message,
+        response: error.response?.data,
+        status: error.response?.status,
+        headers: error.response?.headers
+      });
+      
+      let errorMessage = 'Failed to submit medical record. ';
+      
+      if (error.response?.status === 401) {
+        errorMessage += '\n\nAuthentication error. Please log in again.';
+        // You might want to redirect to login here
+      } else if (error.response?.status === 403) {
+        errorMessage += '\n\nAccess denied. You may not have permission to submit this form.';
+      } else if (error.response?.status === 400) {
+        errorMessage += '\n\nInvalid data. Please check all fields and try again.';
+      } else if (error.response?.status >= 500) {
+        errorMessage += '\n\nServer error. Please try again later.';
+      } else if (error.response?.data?.errors) {
+        errorMessage += '\n\nServer errors:\n' + 
+          error.response.data.errors.map(e => `- ${e.message}`).join('\n');
+      } else if (error.message) {
+        errorMessage += '\n\nError: ' + error.message;
+      } else {
+        errorMessage += '\n\nPlease check the console for more details and try again.';
+      }
+      
+      alert(errorMessage);
     } finally {
       setIsSubmitting(false);
+      console.log('[Initial Medical Record Form] Submission process completed');
     }
   };
 

--- a/mds-frontend/src/modules/record-forms/initial-record/medical/initial-medical-record-form.jsx
+++ b/mds-frontend/src/modules/record-forms/initial-record/medical/initial-medical-record-form.jsx
@@ -11,7 +11,15 @@ import { Button } from './form-elements';
 import { createInitialMedicalRecord } from '../../../../services/emr-service';
 import { validateFormData, sanitizeFormData, logDataStructure } from '../../../../utils/data-transformer';
 
-const InitialMedicalRecordForm = () => {
+/**
+ * Initial Medical Record Form Component
+ * Can be used as a standalone page or within a modal
+ * 
+ * @param {Object} props
+ * @param {Function} props.onComplete - Optional callback when form is successfully submitted
+ * @param {boolean} props.isModal - Whether the form is displayed in a modal (affects styling)
+ */
+const InitialMedicalRecordForm = ({ onComplete, isModal = false }) => {
   const navigate = useNavigate();
   const [currentStep, setCurrentStep] = useState(0);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -241,8 +249,13 @@ const InitialMedicalRecordForm = () => {
       
       alert('Medical record submitted successfully! You can now access the system.');
       
-      // Navigate to dashboard
-      navigate('/dashboard');
+      // If onComplete callback is provided (modal mode), call it
+      if (onComplete) {
+        onComplete(result);
+      } else {
+        // Navigate to dashboard (standalone page mode)
+        navigate('/dashboard');
+      }
       
     } catch (error) {
       console.error('[Initial Medical Record Form] Submission error:', error);
@@ -333,17 +346,19 @@ const InitialMedicalRecordForm = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-primary-50 via-white to-accent-50 py-8 px-4">
-      <div className="max-w-5xl mx-auto">
-        {/* Header */}
-        <div className="text-center mb-8">
-          <h1 className="text-3xl md:text-4xl font-heading font-bold text-secondary-900 mb-2">
-            Initial Medical Record
-          </h1>
-          <p className="text-secondary-600">
-            Please complete your medical information to access the system
-          </p>
-        </div>
+    <div className={`${isModal ? 'bg-gradient-to-br from-primary-50 via-white to-accent-50 p-6' : 'min-h-screen bg-gradient-to-br from-primary-50 via-white to-accent-50 py-8 px-4'}`}>
+      <div className={`${isModal ? 'w-full' : 'max-w-5xl mx-auto'}`}>
+        {/* Header - Only show in standalone mode, modal has its own header */}
+        {!isModal && (
+          <div className="text-center mb-8">
+            <h1 className="text-3xl md:text-4xl font-heading font-bold text-secondary-900 mb-2">
+              Initial Medical Record
+            </h1>
+            <p className="text-secondary-600">
+              Please complete your medical information to access the system
+            </p>
+          </div>
+        )}
 
         {/* Progress Stepper */}
         <ProgressStepper 
@@ -355,12 +370,12 @@ const InitialMedicalRecordForm = () => {
         />
 
         {/* Form Content */}
-        <div className="bg-white rounded-2xl shadow-xl p-6 md:p-8 mb-6">
+        <div className={`bg-white rounded-2xl shadow-xl p-6 md:p-8 mb-6 ${isModal ? 'shadow-none border border-gray-200' : ''}`}>
           {renderStepContent()}
         </div>
 
         {/* Navigation Buttons */}
-        <div className="flex justify-between items-center bg-white rounded-2xl shadow-xl p-6">
+        <div className={`flex justify-between items-center bg-white rounded-2xl shadow-xl p-6 ${isModal ? 'shadow-none border border-gray-200 sticky bottom-0' : ''}`}>
           <Button
             variant="outline"
             onClick={handleBack}

--- a/mds-frontend/src/modules/record-forms/initial-record/medical/medical-background.jsx
+++ b/mds-frontend/src/modules/record-forms/initial-record/medical/medical-background.jsx
@@ -1,6 +1,63 @@
 import React, { useState } from 'react';
 import { Checkbox, Input, Textarea, Select } from './form-elements';
 
+// Immunization/Vaccine options (catalog - can grow over time)
+const immunizationOptions = [
+  { id: 'bcg', label: 'BCG' },
+  { id: 'chickenPox', label: 'Chicken Pox' },
+  { id: 'hepatitisA', label: 'Hepatitis A' },
+  { id: 'hepatitisB', label: 'Hepatitis B' },
+  { id: 'hpv', label: 'HPV' },
+  { id: 'mmr', label: 'MMR' },
+  { id: 'antiTetanus', label: 'Anti-Tetanus' },
+  { id: 'covidVaccine', label: 'COVID Vaccine (1st and 2nd Dose)' },
+  { id: 'covidBooster', label: 'COVID Vaccine Booster' },
+];
+
+// COVID Vaccine Types (catalog)
+const covidVaccineTypes = [
+  { id: 'astrazeneca', label: 'Astrazeneca' },
+  { id: 'janssen', label: 'Janssen' },
+  { id: 'moderna', label: 'Moderna' },
+  { id: 'pfizer', label: 'Pfizer' },
+  { id: 'sinovac', label: 'Sinovac' },
+  { id: 'sinopharm', label: 'Sinopharm' },
+  { id: 'sputnik', label: 'Sputnik' },
+];
+
+// Allergy categories (catalog)
+const allergyCategories = [
+  { id: 'beverages', label: 'Beverages' },
+  { id: 'food', label: 'Food' },
+  { id: 'medicine', label: 'Medicine' },
+  { id: 'dustSmoke', label: 'Dust, Smoke' },
+  { id: 'soapsLotions', label: 'Soaps, Lotions, Fabric conditioner' },
+  { id: 'colognePerfume', label: 'Cologne, Perfume' },
+  { id: 'fur', label: 'Fur, Animal hair' },
+];
+
+// Hospitalization reasons (catalog)
+const hospitalizationReasons = [
+  { id: 'vehicleAccident', label: 'Vehicle Accident' },
+  { id: 'sportsInjury', label: 'Sports Injury' },
+  { id: 'fallInjury', label: 'Fall/Slip Injury' },
+  { id: 'workAccident', label: 'Work/School Accident' },
+  { id: 'medicalCondition', label: 'Medical Condition/Illness' },
+  { id: 'surgery', label: 'Scheduled Surgery' },
+  { id: 'other', label: 'Other' },
+];
+
+// Medication categories (catalog)
+const medicationCategories = [
+  { id: 'antibiotics', label: 'Antibiotics' },
+  { id: 'painRelievers', label: 'Pain Relievers' },
+  { id: 'vitamins', label: 'Vitamins/Supplements' },
+  { id: 'maintenance', label: 'Maintenance Medication' },
+  { id: 'contraceptives', label: 'Contraceptives' },
+  { id: 'antiHistamines', label: 'Anti-Histamines' },
+  { id: 'other', label: 'Other' },
+];
+
 const MedicalBackgroundForm = ({ data, onChange }) => {
   const [activeAccordion, setActiveAccordion] = useState('immunizations');
 
@@ -12,6 +69,20 @@ const MedicalBackgroundForm = ({ data, onChange }) => {
     onChange({
       ...data,
       immunizations: { ...data.immunizations, [vaccine]: checked },
+    });
+  };
+
+  const handleCovidVaccineTypeChange = (type, checked) => {
+    onChange({
+      ...data,
+      covidVaccineType: { ...data.covidVaccineType, [type]: checked },
+    });
+  };
+
+  const handleAllergyChange = (allergyId, checked) => {
+    onChange({
+      ...data,
+      allergies: { ...data.allergies, [allergyId]: checked },
     });
   };
 
@@ -49,73 +120,54 @@ const MedicalBackgroundForm = ({ data, onChange }) => {
       <div className="form-section">
         <h3 className="text-xl font-heading font-semibold text-secondary-900 mb-6 flex items-center">
           <svg className="w-6 h-6 mr-2 text-primary-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z" />
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
           </svg>
-          Medical Background & Lifestyle
+          Medical Background
         </h3>
 
-        {/* Immunizations */}
+        {/* Immunization & Vaccines (Combined) */}
         <AccordionSection
           id="immunizations"
-          title="Immunizations"
+          title="Immunization & Vaccines"
           icon={
-            <svg className="w-5 h-5 mr-2 text-success-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="w-5 h-5 mr-2 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
           }
         >
-          <p className="text-sm text-secondary-600 mb-4">Have you had any vaccinations from these?</p>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-            <Checkbox
-              label="BCG"
-              checked={data.immunizations?.bcg || false}
-              onChange={(e) => handleImmunizationChange('bcg', e.target.checked)}
-            />
-            <Checkbox
-              label="Chicken Pox"
-              checked={data.immunizations?.chickenPox || false}
-              onChange={(e) => handleImmunizationChange('chickenPox', e.target.checked)}
-            />
-            <Checkbox
-              label="Hepatitis A"
-              checked={data.immunizations?.hepatitisA || false}
-              onChange={(e) => handleImmunizationChange('hepatitisA', e.target.checked)}
-            />
-            <Checkbox
-              label="Hepatitis B"
-              checked={data.immunizations?.hepatitisB || false}
-              onChange={(e) => handleImmunizationChange('hepatitisB', e.target.checked)}
-            />
-            <Checkbox
-              label="HPV"
-              checked={data.immunizations?.hpv || false}
-              onChange={(e) => handleImmunizationChange('hpv', e.target.checked)}
-            />
-            <Checkbox
-              label="MMR (Measles, Mumps, Rubella)"
-              checked={data.immunizations?.mmr || false}
-              onChange={(e) => handleImmunizationChange('mmr', e.target.checked)}
-            />
-            <Checkbox
-              label="Anti-Tetanus"
-              checked={data.immunizations?.antiTetanus || false}
-              onChange={(e) => handleImmunizationChange('antiTetanus', e.target.checked)}
-            />
-            <Checkbox
-              label="COVID Vaccine (1st and 2nd Dose)"
-              checked={data.immunizations?.covidVaccine || false}
-              onChange={(e) => handleImmunizationChange('covidVaccine', e.target.checked)}
-            />
-            <Checkbox
-              label="COVID Vaccine Booster"
-              checked={data.immunizations?.covidBooster || false}
-              onChange={(e) => handleImmunizationChange('covidBooster', e.target.checked)}
-            />
+          <p className="text-sm text-secondary-600 mb-4">Select all immunizations/vaccines you have received:</p>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-4">
+            {immunizationOptions.map((option) => (
+              <Checkbox
+                key={option.id}
+                label={option.label}
+                checked={data.immunizations?.[option.id] || false}
+                onChange={(e) => handleImmunizationChange(option.id, e.target.checked)}
+              />
+            ))}
           </div>
+
+          {/* COVID Vaccine Type Selection */}
+          {(data.immunizations?.covidVaccine || data.immunizations?.covidBooster) && (
+            <div className="mt-4 p-4 bg-blue-50 rounded-lg">
+              <label className="form-label mb-3">Specify COVID Vaccine Type(s):</label>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                {covidVaccineTypes.map((type) => (
+                  <Checkbox
+                    key={type.id}
+                    label={type.label}
+                    checked={data.covidVaccineType?.[type.id] || false}
+                    onChange={(e) => handleCovidVaccineTypeChange(type.id, e.target.checked)}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
           <div className="mt-4">
             <Input
-              label="Other:"
-              placeholder="Specify other vaccines..."
+              label="Other Vaccines (specify):"
+              placeholder="Enter any other vaccines received..."
               value={data.immunizationOther || ''}
               onChange={(e) => handleChange('immunizationOther', e.target.value)}
             />
@@ -162,173 +214,28 @@ const MedicalBackgroundForm = ({ data, onChange }) => {
           
           {data.hasAllergies === 'Yes' && (
             <div className="mt-4">
-              <p className="text-sm text-secondary-600 mb-3">If Yes, What are you allergic to?</p>
+              <p className="text-sm text-secondary-600 mb-3">What are you allergic to? (Select all that apply)</p>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                <Checkbox
-                  label="Beverages (Please Specify)"
-                  checked={data.allergies?.beverages || false}
-                  onChange={(e) => onChange({ ...data, allergies: { ...data.allergies, beverages: e.target.checked } })}
-                />
-                <Checkbox
-                  label="Food (Please Specify)"
-                  checked={data.allergies?.food || false}
-                  onChange={(e) => onChange({ ...data, allergies: { ...data.allergies, food: e.target.checked } })}
-                />
-                <Checkbox
-                  label="Medicine (Please Specify)"
-                  checked={data.allergies?.medicine || false}
-                  onChange={(e) => onChange({ ...data, allergies: { ...data.allergies, medicine: e.target.checked } })}
-                />
-                <Checkbox
-                  label="Others (Dust, Smoke)"
-                  checked={data.allergies?.dustSmoke || false}
-                  onChange={(e) => onChange({ ...data, allergies: { ...data.allergies, dustSmoke: e.target.checked } })}
-                />
-                <Checkbox
-                  label="Others (Soaps, Lotions, Fabric conditioner)"
-                  checked={data.allergies?.soapsLotions || false}
-                  onChange={(e) => onChange({ ...data, allergies: { ...data.allergies, soapsLotions: e.target.checked } })}
-                />
-                <Checkbox
-                  label="Others (Cologne, Perfume)"
-                  checked={data.allergies?.colognePerfume || false}
-                  onChange={(e) => onChange({ ...data, allergies: { ...data.allergies, colognePerfume: e.target.checked } })}
-                />
-                <Checkbox
-                  label="Others (Fur etc.)"
-                  checked={data.allergies?.fur || false}
-                  onChange={(e) => onChange({ ...data, allergies: { ...data.allergies, fur: e.target.checked } })}
-                />
-                <Checkbox
-                  label="Others (Please specify)"
-                  checked={data.allergies?.othersSpecify || false}
-                  onChange={(e) => onChange({ ...data, allergies: { ...data.allergies, othersSpecify: e.target.checked } })}
-                />
-                <Checkbox
-                  label="None"
-                  checked={data.allergies?.none || false}
-                  onChange={(e) => onChange({ ...data, allergies: { ...data.allergies, none: e.target.checked } })}
-                />
+                {allergyCategories.map((allergy) => (
+                  <div key={allergy.id} className="flex items-start gap-2">
+                    <Checkbox
+                      label={allergy.label}
+                      checked={data.allergies?.[allergy.id] || false}
+                      onChange={(e) => handleAllergyChange(allergy.id, e.target.checked)}
+                    />
+                  </div>
+                ))}
               </div>
               <div className="mt-4">
                 <Input
-                  label="Other:"
-                  placeholder="Specify other allergies..."
+                  label="Other allergies or specify details:"
+                  placeholder="Specify additional allergies or details..."
                   value={data.allergyOther || ''}
                   onChange={(e) => handleChange('allergyOther', e.target.value)}
                 />
               </div>
             </div>
           )}
-        </AccordionSection>
-
-        {/* Vaccine Section */}
-        <AccordionSection
-          id="vaccine"
-          title="Vaccine"
-          icon={
-            <svg className="w-5 h-5 mr-2 text-primary-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-          }
-        >
-          {/* COVID Vaccine Type */}
-          <div className="mb-6">
-            <label className="form-label mb-3">What type of COVID Vaccine?</label>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-              <Checkbox
-                label="Astrazeneca"
-                checked={data.covidVaccineType?.astrazeneca || false}
-                onChange={(e) => onChange({ ...data, covidVaccineType: { ...data.covidVaccineType, astrazeneca: e.target.checked } })}
-              />
-              <Checkbox
-                label="Janssen"
-                checked={data.covidVaccineType?.janssen || false}
-                onChange={(e) => onChange({ ...data, covidVaccineType: { ...data.covidVaccineType, janssen: e.target.checked } })}
-              />
-              <Checkbox
-                label="Moderna"
-                checked={data.covidVaccineType?.moderna || false}
-                onChange={(e) => onChange({ ...data, covidVaccineType: { ...data.covidVaccineType, moderna: e.target.checked } })}
-              />
-              <Checkbox
-                label="Pfizer"
-                checked={data.covidVaccineType?.pfizer || false}
-                onChange={(e) => onChange({ ...data, covidVaccineType: { ...data.covidVaccineType, pfizer: e.target.checked } })}
-              />
-              <Checkbox
-                label="Sinovac"
-                checked={data.covidVaccineType?.sinovac || false}
-                onChange={(e) => onChange({ ...data, covidVaccineType: { ...data.covidVaccineType, sinovac: e.target.checked } })}
-              />
-              <Checkbox
-                label="Sinopharm"
-                checked={data.covidVaccineType?.sinopharm || false}
-                onChange={(e) => onChange({ ...data, covidVaccineType: { ...data.covidVaccineType, sinopharm: e.target.checked } })}
-              />
-              <Checkbox
-                label="Sputnik"
-                checked={data.covidVaccineType?.sputnik || false}
-                onChange={(e) => onChange({ ...data, covidVaccineType: { ...data.covidVaccineType, sputnik: e.target.checked } })}
-              />
-              <Checkbox
-                label="None"
-                checked={data.covidVaccineType?.none || false}
-                onChange={(e) => onChange({ ...data, covidVaccineType: { ...data.covidVaccineType, none: e.target.checked } })}
-              />
-            </div>
-          </div>
-
-          {/* COVID Vaccine Booster Type */}
-          <div className="mb-6">
-            <label className="form-label mb-3">What type of COVID Vaccine Booster?</label>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-              <Checkbox
-                label="Astrazeneca"
-                checked={data.covidBoosterType?.astrazeneca || false}
-                onChange={(e) => onChange({ ...data, covidBoosterType: { ...data.covidBoosterType, astrazeneca: e.target.checked } })}
-              />
-              <Checkbox
-                label="Moderna"
-                checked={data.covidBoosterType?.moderna || false}
-                onChange={(e) => onChange({ ...data, covidBoosterType: { ...data.covidBoosterType, moderna: e.target.checked } })}
-              />
-              <Checkbox
-                label="Pfizer"
-                checked={data.covidBoosterType?.pfizer || false}
-                onChange={(e) => onChange({ ...data, covidBoosterType: { ...data.covidBoosterType, pfizer: e.target.checked } })}
-              />
-              <Checkbox
-                label="Sinovac"
-                checked={data.covidBoosterType?.sinovac || false}
-                onChange={(e) => onChange({ ...data, covidBoosterType: { ...data.covidBoosterType, sinovac: e.target.checked } })}
-              />
-              <Checkbox
-                label="None"
-                checked={data.covidBoosterType?.none || false}
-                onChange={(e) => onChange({ ...data, covidBoosterType: { ...data.covidBoosterType, none: e.target.checked } })}
-              />
-            </div>
-            <div className="mt-4">
-              <Input
-                label="Other:"
-                placeholder="Specify other booster type..."
-                value={data.covidBoosterOther || ''}
-                onChange={(e) => handleChange('covidBoosterOther', e.target.value)}
-              />
-            </div>
-          </div>
-
-          {/* Other Vaccine */}
-          <div>
-            <Textarea
-              label="Other Vaccine?"
-              placeholder="Please specify any other vaccines..."
-              value={data.otherVaccine || ''}
-              onChange={(e) => handleChange('otherVaccine', e.target.value)}
-              rows={3}
-            />
-          </div>
         </AccordionSection>
 
         {/* History of Hospitalizations */}
@@ -371,14 +278,44 @@ const MedicalBackgroundForm = ({ data, onChange }) => {
           </div>
           
           {data.hasHospitalization === 'Yes' && (
-            <div className="mt-4">
-              <Textarea
-                label="If Yes, When did you've been hospitalized? What is the reason for the hospitalization?"
-                placeholder="Your answer"
-                value={data.hospitalizationDetails || ''}
-                onChange={(e) => handleChange('hospitalizationDetails', e.target.value)}
-                rows={3}
-              />
+            <div className="mt-4 space-y-4">
+              <div>
+                <label className="form-label mb-2">Reason for Hospitalization:</label>
+                <div className="space-y-2">
+                  {hospitalizationReasons.map((reason) => (
+                    <label key={reason.id} className="flex items-center">
+                      <input
+                        type="radio"
+                        name="hospitalizationReason"
+                        value={reason.id}
+                        checked={data.hospitalizationReason === reason.id}
+                        onChange={(e) => handleChange('hospitalizationReason', e.target.value)}
+                        className="form-checkbox"
+                      />
+                      <span className="ml-2 text-secondary-700">{reason.label}</span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+              
+              <div>
+                <Input
+                  label="Date of Admission:"
+                  type="date"
+                  value={data.hospitalizationDate || ''}
+                  onChange={(e) => handleChange('hospitalizationDate', e.target.value)}
+                />
+              </div>
+              
+              <div>
+                <Textarea
+                  label="Additional Notes (optional):"
+                  placeholder="Any additional details about the hospitalization..."
+                  value={data.hospitalizationNotes || ''}
+                  onChange={(e) => handleChange('hospitalizationNotes', e.target.value)}
+                  rows={2}
+                />
+              </div>
             </div>
           )}
         </AccordionSection>
@@ -395,7 +332,7 @@ const MedicalBackgroundForm = ({ data, onChange }) => {
         >
           <div className="mb-4">
             <label className="form-label">HAVE YOU UNDERGONE SURGERY IN THE PAST YEARS? <span className="text-error-500">*</span></label>
-            <p className="text-xs text-secondary-500 mb-2">( Ikaw ba ay sumailalim sa operasyon sa mga nakaraang taon? )</p>
+            <p className="text-xs text-secondary-500 mb-2">(Ikaw ba ay sumailalim sa operasyon sa mga nakaraang taon?)</p>
             <div className="flex gap-6 mt-2">
               <label className="flex items-center">
                 <input
@@ -423,14 +360,34 @@ const MedicalBackgroundForm = ({ data, onChange }) => {
           </div>
           
           {data.hasOperation === 'Yes' && (
-            <div className="mt-4">
-              <Textarea
-                label="If Yes, What kind of Operations? and When?"
-                placeholder="Your answer"
-                value={data.operationDetails || ''}
-                onChange={(e) => handleChange('operationDetails', e.target.value)}
-                rows={3}
-              />
+            <div className="mt-4 space-y-4">
+              <div>
+                <Input
+                  label="What procedure was performed?"
+                  placeholder="e.g., Appendectomy, Cesarean Section..."
+                  value={data.operationProcedure || ''}
+                  onChange={(e) => handleChange('operationProcedure', e.target.value)}
+                />
+              </div>
+              
+              <div>
+                <Input
+                  label="Date of Operation:"
+                  type="date"
+                  value={data.operationDate || ''}
+                  onChange={(e) => handleChange('operationDate', e.target.value)}
+                />
+              </div>
+              
+              <div>
+                <Textarea
+                  label="Additional Notes (optional):"
+                  placeholder="Any additional details about the operation..."
+                  value={data.operationNotes || ''}
+                  onChange={(e) => handleChange('operationNotes', e.target.value)}
+                  rows={2}
+                />
+              </div>
             </div>
           )}
         </AccordionSection>
@@ -474,42 +431,47 @@ const MedicalBackgroundForm = ({ data, onChange }) => {
           </div>
           
           {data.hasMedications === 'Yes' && (
-            <div className="mt-4">
-              <Textarea
-                label="If Yes, What Medication/s are you taking ?"
-                placeholder="Your answer"
-                value={data.medicationDetails || ''}
-                onChange={(e) => handleChange('medicationDetails', e.target.value)}
-                rows={3}
-              />
+            <div className="mt-4 space-y-4">
+              <div>
+                <label className="form-label mb-2">Medication Category:</label>
+                <div className="flex flex-wrap gap-2">
+                  {medicationCategories.map((category) => (
+                    <button
+                      key={category.id}
+                      type="button"
+                      className={`px-4 py-2 rounded-full text-sm font-medium transition-colors ${
+                        data.medicationCategory === category.id
+                          ? 'bg-primary-600 text-white'
+                          : 'bg-neutral-100 text-secondary-700 hover:bg-neutral-200'
+                      }`}
+                      onClick={() => handleChange('medicationCategory', category.id)}
+                    >
+                      {category.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              
+              <div>
+                <Textarea
+                  label="Reason for taking medication:"
+                  placeholder="Why are you taking this medication?"
+                  value={data.medicationReason || ''}
+                  onChange={(e) => handleChange('medicationReason', e.target.value)}
+                  rows={2}
+                />
+              </div>
+              
+              <div>
+                <Input
+                  label="Medication Name(s):"
+                  placeholder="List the medication names..."
+                  value={data.medicationDetails || ''}
+                  onChange={(e) => handleChange('medicationDetails', e.target.value)}
+                />
+              </div>
             </div>
           )}
-        </AccordionSection>
-
-        {/* Body Modifications */}
-        <AccordionSection
-          id="modifications"
-          title="Body Modifications"
-          icon={
-            <svg className="w-5 h-5 mr-2 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01" />
-            </svg>
-          }
-        >
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <Input
-              label="Tattoo"
-              placeholder="Location (if any)"
-              value={data.tattooLocation || ''}
-              onChange={(e) => handleChange('tattooLocation', e.target.value)}
-            />
-            <Input
-              label="Piercing"
-              placeholder="Location (if any)"
-              value={data.piercingLocation || ''}
-              onChange={(e) => handleChange('piercingLocation', e.target.value)}
-            />
-          </div>
         </AccordionSection>
 
         {/* Lifestyle */}
@@ -599,10 +561,11 @@ const MedicalBackgroundForm = ({ data, onChange }) => {
               </div>
               {data.alcoholDrinker === 'yes' && (
                 <Input
-                  label="Number of bottles / frequency"
+                  label="Frequency"
                   placeholder="e.g., 2 bottles per week"
                   value={data.alcoholFrequency || ''}
-                  onChange={(e) => handleChange('alcoholFrequency', e.target.value)}
+                  onChange={(e) => handleChange('alcoholFrequency', e.target.value.slice(0, 30))}
+                  maxLength={30}
                 />
               )}
             </div>
@@ -661,34 +624,6 @@ const MedicalBackgroundForm = ({ data, onChange }) => {
                 </div>
               </>
             )}
-          </div>
-        </AccordionSection>
-
-        {/* Physical Measurements */}
-        <AccordionSection
-          id="measurements"
-          title="Physical Measurements"
-          icon={
-            <svg className="w-5 h-5 mr-2 text-teal-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3" />
-            </svg>
-          }
-        >
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <Input
-              label="Height (cm)"
-              type="number"
-              placeholder="Enter height"
-              value={data.height || ''}
-              onChange={(e) => handleChange('height', e.target.value)}
-            />
-            <Input
-              label="Weight (kg)"
-              type="number"
-              placeholder="Enter weight"
-              value={data.weight || ''}
-              onChange={(e) => handleChange('weight', e.target.value)}
-            />
           </div>
         </AccordionSection>
       </div>

--- a/mds-frontend/src/modules/record-forms/initial-record/medical/medical-history.jsx
+++ b/mds-frontend/src/modules/record-forms/initial-record/medical/medical-history.jsx
@@ -52,7 +52,19 @@ const MedicalHistoryForm = ({ data, onChange }) => {
 
   const handleFamilyConditionChange = (conditionId, checked) => {
     const family = { ...data.family, [conditionId]: checked };
-    onChange({ ...data, family });
+    // Clear the "who has it" field if unchecked
+    if (!checked) {
+      const familyWhoHasIt = { ...data.familyWhoHasIt };
+      delete familyWhoHasIt[conditionId];
+      onChange({ ...data, family, familyWhoHasIt });
+    } else {
+      onChange({ ...data, family });
+    }
+  };
+
+  const handleFamilyWhoHasItChange = (conditionId, value) => {
+    const familyWhoHasIt = { ...data.familyWhoHasIt, [conditionId]: value };
+    onChange({ ...data, familyWhoHasIt });
   };
 
   const handleFamilyOtherChange = (value) => {
@@ -108,14 +120,6 @@ const MedicalHistoryForm = ({ data, onChange }) => {
                 />
               </div>
             ))}
-            {/* None Option */}
-            <div className="border border-neutral-200 rounded-lg p-4">
-              <Checkbox
-                label="None"
-                checked={data.selfNone || false}
-                onChange={(e) => onChange({ ...data, selfNone: e.target.checked })}
-              />
-            </div>
           </div>
           {/* Other Option - Separate at bottom */}
           <div className="mt-6 border-2 border-neutral-300 rounded-lg p-4">
@@ -142,7 +146,7 @@ const MedicalHistoryForm = ({ data, onChange }) => {
       {activeTab === 'family' && (
         <div>
           <p className="text-sm text-secondary-600 mb-4">
-            Check any conditions that apply to your immediate family members:
+            Check any conditions that apply to your immediate family members and specify who has it:
           </p>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {familyMedicalConditions.map((condition) => (
@@ -152,16 +156,18 @@ const MedicalHistoryForm = ({ data, onChange }) => {
                   checked={data.family?.[condition.id] || false}
                   onChange={(e) => handleFamilyConditionChange(condition.id, e.target.checked)}
                 />
+                {data.family?.[condition.id] && (
+                  <div className="mt-2 ml-6">
+                    <Input
+                      placeholder="Who has this condition? (e.g., Mother, Father, Sibling)"
+                      value={data.familyWhoHasIt?.[condition.id] || ''}
+                      onChange={(e) => handleFamilyWhoHasItChange(condition.id, e.target.value)}
+                      className="text-sm"
+                    />
+                  </div>
+                )}
               </div>
             ))}
-            {/* None Option */}
-            <div className="border border-neutral-200 rounded-lg p-4">
-              <Checkbox
-                label="None"
-                checked={data.familyNone || false}
-                onChange={(e) => onChange({ ...data, familyNone: e.target.checked })}
-              />
-            </div>
           </div>
           {/* Other Option - Separate at bottom */}
           <div className="mt-6 border-2 border-neutral-300 rounded-lg p-4">
@@ -171,12 +177,17 @@ const MedicalHistoryForm = ({ data, onChange }) => {
               onChange={(e) => onChange({ ...data, familyOtherChecked: e.target.checked })}
             />
             {data.familyOtherChecked && (
-              <div className="mt-3">
+              <div className="mt-3 space-y-2">
                 <Textarea
                   placeholder="Please specify other medical conditions..."
                   value={data.familyOther || ''}
                   onChange={(e) => handleFamilyOtherChange(e.target.value)}
-                  rows={3}
+                  rows={2}
+                />
+                <Input
+                  placeholder="Who has this condition?"
+                  value={data.familyOtherWhoHasIt || ''}
+                  onChange={(e) => onChange({ ...data, familyOtherWhoHasIt: e.target.value })}
                 />
               </div>
             )}

--- a/mds-frontend/src/modules/record-forms/initial-record/medical/obygyne.jsx
+++ b/mds-frontend/src/modules/record-forms/initial-record/medical/obygyne.jsx
@@ -35,17 +35,6 @@ const OBGYNEForm = ({ data, onChange }) => {
           />
         </div>
 
-        {/* Menarche Year/Age */}
-        <div className="mb-6">
-          <label className="form-label">Menarche Year / Age</label>
-          <p className="text-xs text-secondary-500 mb-2">(Pinaka-unang regla)</p>
-          <Input
-            placeholder="Your answer"
-            value={data.menarcheYearAge || ''}
-            onChange={(e) => handleChange('menarcheYearAge', e.target.value)}
-          />
-        </div>
-
         {/* Menstruation Duration */}
         <div className="mb-6">
           <label className="form-label">Menstruation Duration ?</label>
@@ -54,16 +43,6 @@ const OBGYNEForm = ({ data, onChange }) => {
             placeholder="Your answer"
             value={data.menstruationDuration || ''}
             onChange={(e) => handleChange('menstruationDuration', e.target.value)}
-          />
-        </div>
-
-        {/* Pads per day */}
-        <div className="mb-6">
-          <label className="form-label">How many pad/s per day</label>
-          <Input
-            placeholder="Your answer"
-            value={data.padsPerDay || ''}
-            onChange={(e) => handleChange('padsPerDay', e.target.value)}
           />
         </div>
 

--- a/mds-frontend/src/modules/record-forms/initial-record/medical/personal-info.jsx
+++ b/mds-frontend/src/modules/record-forms/initial-record/medical/personal-info.jsx
@@ -127,7 +127,6 @@ const PersonalInfoForm = ({ data, onChange }) => {
             options={[
               { value: 'Male', label: 'Male' },
               { value: 'Female', label: 'Female' },
-              { value: 'Other', label: 'Other' },
             ]}
           />
           <Select
@@ -138,8 +137,8 @@ const PersonalInfoForm = ({ data, onChange }) => {
             options={[
               { value: 'Single', label: 'Single' },
               { value: 'Married', label: 'Married' },
-              { value: 'Divorced', label: 'Divorced' },
               { value: 'Widowed', label: 'Widowed' },
+              { value: 'Separated', label: 'Separated' },
             ]}
           />
           <Input

--- a/mds-frontend/src/pages/Dashboard.jsx
+++ b/mds-frontend/src/pages/Dashboard.jsx
@@ -1,23 +1,95 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import Layout from '../components/layout/layout.jsx';
 import DashboardHome from '../modules/dashboard/dashboard-home.jsx';
 import RecordUpdateForm from '../modules/record-forms/update-record/record-update-form.jsx';
 import AppointmentPage from '../modules/appointment/appointment-page.jsx';
 import MedicineRequestPage from '../modules/medicine-request/medicine-request-page.jsx';
+import InitialRecordModal from '../components/modals/initial-record-modal.jsx';
+import InitialMedicalRecordForm from '../modules/record-forms/initial-record/medical/initial-medical-record-form.jsx';
+import { checkInitialRecordStatus } from '../services/emr-service.js';
+import { useDetectRoleFromSubdomain } from '../hooks/use-role.js';
 
 const Dashboard = () => {
+  const { role } = useDetectRoleFromSubdomain();
+  const [showInitialRecordModal, setShowInitialRecordModal] = useState(false);
+  const [isCheckingStatus, setIsCheckingStatus] = useState(true);
+
+  // Check if user needs to complete initial medical record (students only)
+  useEffect(() => {
+    const checkRecordStatus = async () => {
+      // Only check for students, not staff
+      if (role === 'staff' || role === 'admin') {
+        console.log('[Dashboard] Staff/admin user - skipping initial record check');
+        setIsCheckingStatus(false);
+        return;
+      }
+
+      try {
+        console.log('[Dashboard] Checking initial record status for student...');
+        const { needsInitialRecord, status } = await checkInitialRecordStatus();
+        
+        console.log('[Dashboard] Initial record check result:', { needsInitialRecord, status });
+        
+        if (needsInitialRecord) {
+          setShowInitialRecordModal(true);
+        }
+      } catch (error) {
+        console.error('[Dashboard] Error checking initial record status:', error);
+        // On error, assume they need to fill it out to be safe
+        setShowInitialRecordModal(true);
+      } finally {
+        setIsCheckingStatus(false);
+      }
+    };
+
+    checkRecordStatus();
+  }, [role]);
+
+  // Handle successful completion of initial record
+  const handleInitialRecordComplete = (result) => {
+    console.log('[Dashboard] Initial record completed:', result);
+    setShowInitialRecordModal(false);
+  };
+
+  // Show loading state while checking
+  if (isCheckingStatus) {
+    return (
+      <Layout>
+        <div className="flex items-center justify-center min-h-[60vh]">
+          <div className="text-center">
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600 mx-auto mb-4"></div>
+            <p className="text-secondary-600">Loading your dashboard...</p>
+          </div>
+        </div>
+      </Layout>
+    );
+  }
+
   return (
-    <Layout>
-      <Routes>
-        <Route path="/" element={<DashboardHome />} />
-        <Route path="/record-update" element={<RecordUpdateForm />} />
-        <Route path="/appointments" element={<AppointmentPage />} />
-        <Route path="/medicine-request" element={<MedicineRequestPage />} />
-        <Route path="/e-consultation" element={<div>E-Consultation - Coming Soon</div>} />
-        <Route path="*" element={<Navigate to="/" replace />} />
-      </Routes>
-    </Layout>
+    <>
+      {/* Initial Medical Record Modal - Only for students who haven't completed it */}
+      <InitialRecordModal 
+        isOpen={showInitialRecordModal}
+        onComplete={handleInitialRecordComplete}
+      >
+        <InitialMedicalRecordForm 
+          isModal={true}
+          onComplete={handleInitialRecordComplete}
+        />
+      </InitialRecordModal>
+
+      <Layout>
+        <Routes>
+          <Route path="/" element={<DashboardHome />} />
+          <Route path="/record-update" element={<RecordUpdateForm />} />
+          <Route path="/appointments" element={<AppointmentPage />} />
+          <Route path="/medicine-request" element={<MedicineRequestPage />} />
+          <Route path="/e-consultation" element={<div>E-Consultation - Coming Soon</div>} />
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </Layout>
+    </>
   );
 };
 

--- a/mds-frontend/src/services/emr-service.js
+++ b/mds-frontend/src/services/emr-service.js
@@ -1,0 +1,799 @@
+/**
+ * EMR Service - Handles all GraphQL mutations and queries for EMR data
+ */
+
+import { axiosRequest } from '../packages-core-adapter';
+
+/**
+ * Send a GraphQL request to the patient EMR endpoint
+ * @param {string} query - GraphQL query/mutation string
+ * @param {object} variables - Variables for the GraphQL operation
+ * @returns {Promise} Response from the server
+ */
+const sendGraphQLRequest = async (query, variables = {}) => {
+  console.log('[EMR Service] Sending GraphQL request:', {
+    query: query,
+    variables: JSON.stringify(variables, null, 2)
+  });
+
+  try {
+    const response = await axiosRequest.post('/emr/patient', {
+      query,
+      variables
+    });
+
+    console.log('[EMR Service] GraphQL response received:', response.data);
+    
+    if (response.data.errors) {
+      console.error('[EMR Service] GraphQL errors:', JSON.stringify(response.data.errors, null, 2));
+      response.data.errors.forEach((err, i) => {
+        console.error(`[EMR Service] Error ${i + 1}:`, err.message);
+        if (err.locations) console.error(`[EMR Service] Location:`, err.locations);
+        if (err.path) console.error(`[EMR Service] Path:`, err.path);
+        if (err.extensions) console.error(`[EMR Service] Extensions:`, err.extensions);
+      });
+      throw new Error(response.data.errors[0]?.message || 'GraphQL error occurred');
+    }
+
+    return response.data.data;
+  } catch (error) {
+    // If the error response contains GraphQL errors, log them
+    if (error.response?.data?.errors) {
+      console.error('[EMR Service] GraphQL Errors from response:');
+      error.response.data.errors.forEach((err, i) => {
+        console.error(`[EMR Service] Error ${i + 1}:`, err.message);
+        if (err.locations) console.error(`[EMR Service] Location:`, err.locations);
+        if (err.path) console.error(`[EMR Service] Path:`, err.path);
+        if (err.extensions) console.error(`[EMR Service] Extensions:`, err.extensions);
+      });
+    }
+    
+    console.error('[EMR Service] Request failed:', {
+      message: error.message,
+      response: error.response?.data,
+      status: error.response?.status
+    });
+    throw error;
+  }
+};
+
+/**
+ * Create an update ticket (required before making any profile mutations)
+ * @param {string} scope - 'Medical', 'Dental', or 'Both'
+ */
+const createUpdateTicket = async (scope = 'Both') => {
+  console.log('[EMR Service] Creating update ticket with scope:', scope);
+  
+  const mutation = `
+    mutation CreateUpdateTicket($scope: UpdateScope!) {
+      createUpdateTicket(scope: $scope)
+    }
+  `;
+  
+  const data = await sendGraphQLRequest(mutation, { scope });
+  console.log('[EMR Service] Update ticket created:', data.createUpdateTicket);
+  return data.createUpdateTicket;
+};
+
+/**
+ * Submit the update ticket to finalize all changes
+ */
+const submitUpdateTicket = async () => {
+  console.log('[EMR Service] Submitting update ticket...');
+  
+  const mutation = `
+    mutation SubmitUpdateTicket {
+      submitUpdateTicket
+    }
+  `;
+  
+  try {
+    const data = await sendGraphQLRequest(mutation, {});
+    console.log('[EMR Service] Update ticket submitted:', data.submitUpdateTicket);
+    return data.submitUpdateTicket;
+  } catch (error) {
+    // Enhanced error message for backend team
+    if (error.message && error.message.includes('Required records are missing')) {
+      console.error('[EMR Service] ❌ BACKEND VALIDATION ERROR FOR INITIAL PATIENT RECORDS');
+      console.error('[EMR Service] The backend is requiring staff-only records that patients cannot create:');
+      console.error('[EMR Service] - VitalSigns: Only staff can measure blood pressure, heart rate, temperature');
+      console.error('[EMR Service] - VisualAcuity: Requires catalog ID from eye chart tests + has null bug');
+      console.error('[EMR Service] - DentalPhotoRecord: Requires photo UUIDs (staff takes photos)');
+      console.error('[EMR Service] - DentalRecord: Requires tooth placements and oral findings (staff examination)');
+      console.error('[EMR Service] - ObGynHistory: Required for males (should only validate for females)');
+      console.error('[EMR Service]');
+      console.error('[EMR Service] BACKEND TEAM ACTION REQUIRED:');
+      console.error('[EMR Service] 1. Make validation optional for initial patient submissions (scope="Both")');
+      console.error('[EMR Service] 2. Or create separate Medical/Dental scopes for patient initial records');
+      console.error('[EMR Service] 3. Or auto-create empty staff records when patient submits');
+      console.error('[EMR Service] 4. Fix ObGynHistory to only validate for female patients');
+      console.error('[EMR Service] 5. Fix VisualAcuity null handling bug in createVisualAcuityProfile resolver');
+    }
+    throw error;
+  }
+};
+
+/**
+ * Cancel the update ticket (in case of errors)
+ */
+const cancelUpdateTicket = async () => {
+  console.log('[EMR Service] Cancelling update ticket...');
+  
+  const mutation = `
+    mutation CancelUpdateTicket {
+      cancelUpdateTicket
+    }
+  `;
+  
+  try {
+    const data = await sendGraphQLRequest(mutation, {});
+    console.log('[EMR Service] Update ticket cancelled:', data.cancelUpdateTicket);
+    return data.cancelUpdateTicket;
+  } catch (error) {
+    console.warn('[EMR Service] Failed to cancel update ticket:', error.message);
+    return null;
+  }
+};
+
+/**
+ * Create a complete initial medical record
+ * This orchestrates multiple mutations to create all parts of the medical record
+ */
+export const createInitialMedicalRecord = async (formData) => {
+  console.log('[EMR Service] Starting initial medical record creation');
+  console.log('[EMR Service] Form data received:', formData);
+
+  let ticketCreated = false;
+
+  try {
+    const results = {};
+
+    // Step 0: Create an update ticket first (required by backend)
+    console.log('[EMR Service] Step 0: Creating update ticket...');
+    const ticketId = await createUpdateTicket('Both');
+    ticketCreated = true;
+    results.ticketId = ticketId;
+    console.log('[EMR Service] Update ticket created with ID:', ticketId);
+
+    // 1. Create Student Profile (if student)
+    if (formData.personalInfo.program) {
+      console.log('[EMR Service] Creating student profile...');
+      const studentProfile = await createStudentProfile({
+        program: formData.personalInfo.program === 'Other' 
+          ? formData.personalInfo.programOther 
+          : formData.personalInfo.program,
+        year: mapYearLevel(formData.personalInfo.studentCategory),
+        guardian_name: formData.personalInfo.emergencyContacts[0]?.name || '',
+        guardian_relation: formData.personalInfo.emergencyContacts[0]?.relationship || '',
+        guardian_contact: formData.personalInfo.emergencyContacts[0]?.contactNumber || ''
+      });
+      results.studentProfile = studentProfile;
+      console.log('[EMR Service] Student profile created:', studentProfile);
+    }
+
+    // 2. Create Emergency Contacts
+    if (formData.personalInfo.emergencyContacts?.length >= 2) {
+      console.log('[EMR Service] Creating emergency contacts...');
+      const emergencyContact = await createEmergencyContact({
+        firstContact: {
+          contactName: formData.personalInfo.emergencyContacts[0].name,
+          relationship: formData.personalInfo.emergencyContacts[0].relationship,
+          contactNumber: formData.personalInfo.emergencyContacts[0].contactNumber
+        },
+        secondContact: {
+          contactName: formData.personalInfo.emergencyContacts[1].name,
+          relationship: formData.personalInfo.emergencyContacts[1].relationship,
+          contactNumber: formData.personalInfo.emergencyContacts[1].contactNumber
+        }
+      });
+      results.emergencyContact = emergencyContact;
+      console.log('[EMR Service] Emergency contacts created:', emergencyContact);
+    }
+
+    // 3. Create Medical History (REQUIRED by backend)
+    console.log('[EMR Service] Creating medical history...');
+    
+    // Build notes including self conditions, family conditions with "who has it"
+    const medicalHistoryNotes = [];
+    
+    // Add self other notes
+    if (formData.medicalHistory?.selfOther) {
+      medicalHistoryNotes.push(`Self: ${formData.medicalHistory.selfOther}`);
+    }
+    
+    // Add family conditions with who has it information
+    if (formData.medicalHistory?.family) {
+      const familyConditions = Object.entries(formData.medicalHistory.family)
+        .filter(([_, checked]) => checked)
+        .map(([conditionId, _]) => {
+          const whoHasIt = formData.medicalHistory.familyWhoHasIt?.[conditionId];
+          return whoHasIt ? `${conditionId} (${whoHasIt})` : conditionId;
+        });
+      
+      if (familyConditions.length > 0) {
+        medicalHistoryNotes.push(`Family history: ${familyConditions.join(', ')}`);
+      }
+    }
+    
+    // Add family other notes with who has it
+    if (formData.medicalHistory?.familyOther) {
+      const whoHasIt = formData.medicalHistory.familyOtherWhoHasIt;
+      const otherNote = whoHasIt 
+        ? `Family other: ${formData.medicalHistory.familyOther} (${whoHasIt})`
+        : `Family other: ${formData.medicalHistory.familyOther}`;
+      medicalHistoryNotes.push(otherNote);
+    }
+    
+    const medicalHistory = await createMedicalHistory({
+      conditions: [], // Empty - catalog IDs not available in form
+      notes: medicalHistoryNotes.length > 0 ? medicalHistoryNotes.join('; ') : null
+    });
+    results.medicalHistory = medicalHistory;
+    console.log('[EMR Service] Medical history created:', medicalHistory);
+
+    // 4. Create Allergy Profile (REQUIRED by backend)
+    console.log('[EMR Service] Creating allergy profile...');
+    // Build allergy notes from form data
+    let allergyNotes = null;
+    if (formData.medicalBackground?.hasAllergies === 'Yes') {
+      const allergyList = [];
+      
+      // Get selected allergies
+      if (formData.medicalBackground.allergies) {
+        const selectedAllergies = Object.entries(formData.medicalBackground.allergies)
+          .filter(([_, checked]) => checked)
+          .map(([allergyId, _]) => allergyId);
+        
+        if (selectedAllergies.length > 0) {
+          allergyList.push(...selectedAllergies);
+        }
+      }
+      
+      // Add other allergies
+      if (formData.medicalBackground.allergyOther) {
+        allergyList.push(formData.medicalBackground.allergyOther);
+      }
+      
+      if (allergyList.length > 0) {
+        allergyNotes = `Allergies: ${allergyList.join(', ')}`;
+      }
+    }
+    
+    const allergyProfile = await createAllergyProfile({
+      allergies: [], // Empty - catalog IDs not available in form
+      notes: allergyNotes
+    });
+    results.allergyProfile = allergyProfile;
+    console.log('[EMR Service] Allergy profile created:', allergyProfile);
+
+    // 5. Create Hospitalization Profile (REQUIRED by backend)
+    console.log('[EMR Service] Creating hospitalization profile...');
+    // Build hospitalization notes from new form structure
+    const hospitalizationNotes = formData.medicalBackground?.hasHospitalization === 'Yes' ? [
+      formData.medicalBackground.hospitalizationReason 
+        ? `Reason: ${formData.medicalBackground.hospitalizationReason}` 
+        : null,
+      formData.medicalBackground.hospitalizationDate 
+        ? `Date: ${formData.medicalBackground.hospitalizationDate}` 
+        : null,
+      formData.medicalBackground.hospitalizationNotes || null
+    ].filter(Boolean).join('; ') || null : null;
+    
+    const hospitalizationProfile = await createHospitalizationProfile({
+      hospitalizations: [], // Empty - catalog IDs not available in form
+      notes: hospitalizationNotes
+    });
+    results.hospitalizationProfile = hospitalizationProfile;
+    console.log('[EMR Service] Hospitalization profile created:', hospitalizationProfile);
+
+    // 6. Create Operation Profile (REQUIRED by backend)
+    console.log('[EMR Service] Creating operation profile...');
+    // Build operation notes from new form structure
+    const operationNotes = formData.medicalBackground?.hasOperation === 'Yes' ? [
+      formData.medicalBackground.operationProcedure 
+        ? `Procedure: ${formData.medicalBackground.operationProcedure}` 
+        : null,
+      formData.medicalBackground.operationDate 
+        ? `Date: ${formData.medicalBackground.operationDate}` 
+        : null,
+      formData.medicalBackground.operationNotes || null
+    ].filter(Boolean).join('; ') || null : null;
+    
+    const operationProfile = await createOperationProfile({
+      operations: [], // Empty - catalog IDs not available in form
+      notes: operationNotes
+    });
+    results.operationProfile = operationProfile;
+    console.log('[EMR Service] Operation profile created:', operationProfile);
+
+    // 7. Create Medication Profile (REQUIRED by backend)
+    console.log('[EMR Service] Creating medication profile...');
+    // Build medication notes from new form structure
+    const medicationNotes = formData.medicalBackground?.hasMedications === 'Yes' ? [
+      formData.medicalBackground.medicationCategory 
+        ? `Category: ${formData.medicalBackground.medicationCategory}` 
+        : null,
+      formData.medicalBackground.medicationReason 
+        ? `Reason: ${formData.medicalBackground.medicationReason}` 
+        : null,
+      formData.medicalBackground.medicationDetails 
+        ? `Medications: ${formData.medicalBackground.medicationDetails}` 
+        : null
+    ].filter(Boolean).join('; ') || null : null;
+    
+    const medicationProfile = await createMedicationProfile({
+      medications: [], // Empty - catalog IDs not available in form
+      notes: medicationNotes
+    });
+    results.medicationProfile = medicationProfile;
+    console.log('[EMR Service] Medication profile created:', medicationProfile);
+
+    // 7a. Create Immunization Profile (REQUIRED by backend)
+    console.log('[EMR Service] Creating immunization profile...');
+    // Build immunization notes from form data
+    let immunizationNotes = null;
+    const immunizationList = [];
+    
+    // Get selected immunizations
+    if (formData.medicalBackground?.immunizations) {
+      const selectedImmunizations = Object.entries(formData.medicalBackground.immunizations)
+        .filter(([_, checked]) => checked)
+        .map(([immunizationId, _]) => immunizationId);
+      
+      if (selectedImmunizations.length > 0) {
+        immunizationList.push(...selectedImmunizations);
+      }
+    }
+    
+    // Get COVID vaccine types if applicable
+    if (formData.medicalBackground?.covidVaccineType) {
+      const covidTypes = Object.entries(formData.medicalBackground.covidVaccineType)
+        .filter(([_, checked]) => checked)
+        .map(([typeId, _]) => typeId);
+      
+      if (covidTypes.length > 0) {
+        immunizationList.push(`COVID vaccine types: ${covidTypes.join(', ')}`);
+      }
+    }
+    
+    // Add other immunizations
+    if (formData.medicalBackground?.immunizationOther) {
+      immunizationList.push(formData.medicalBackground.immunizationOther);
+    }
+    
+    if (immunizationList.length > 0) {
+      immunizationNotes = immunizationList.join('; ');
+    }
+    
+    const immunizationProfile = await createImmunizationProfile({
+      immunizations: [], // Empty - catalog IDs not available in form
+      notes: immunizationNotes
+    });
+    results.immunizationProfile = immunizationProfile;
+    console.log('[EMR Service] Immunization profile created:', immunizationProfile);
+
+    // 8. Create Lifestyle
+    console.log('[EMR Service] Creating lifestyle...');
+    const lifestyle = await createLifestyle({
+      smoker: formData.medicalBackground.smoker === 'yes',
+      numberOfCigarettesPerDay: formData.medicalBackground.smoker === 'yes' 
+        ? parseInt(formData.medicalBackground.smokerSticksPerDay) || null
+        : null,
+      yearsSmoked: formData.medicalBackground.smoker === 'yes'
+        ? parseInt(formData.medicalBackground.smokerYears) || null
+        : null,
+      alcoholConsumer: formData.medicalBackground.alcoholDrinker === 'yes',
+      frequencyOfAlcoholConsumption: formData.medicalBackground.alcoholDrinker === 'yes'
+        ? formData.medicalBackground.alcoholFrequency || null
+        : null,
+      notes: null
+    });
+    results.lifestyle = lifestyle;
+    console.log('[EMR Service] Lifestyle created:', lifestyle);
+
+    // 9. Skip Visual Acuity Profile
+    // Backend has a bug when acuity is null ("record is not defined")
+    // Also requires catalog ID which we don't have
+    console.log('[EMR Service] Skipping visual acuity profile - backend bug with null acuity + requires catalog IDs');
+
+    // 10. Create Dental History
+    console.log('[EMR Service] Creating dental history...');
+    const mappedDentalCleaning = mapDentalCleaningRange(formData.dentalHistory.lastDentalCleaning);
+    console.log('[EMR Service] Mapped dental cleaning range:', formData.dentalHistory.lastDentalCleaning, '=>', mappedDentalCleaning);
+    
+    // seenByDentist is INVERSE of firstTimeDentist
+    // firstTimeDentist='yes' means never seen a dentist before, so seenByDentist=false
+    // firstTimeDentist='no' means has been to dentist before, so seenByDentist=true
+    const seenByDentist = formData.dentalHistory.firstTimeDentist === 'no';
+    console.log('[EMR Service] firstTimeDentist:', formData.dentalHistory.firstTimeDentist, '=> seenByDentist:', seenByDentist);
+    
+    const dentalHistory = await createDentalHistory({
+      seenByDentist: seenByDentist,
+      lastDentalCleaning: mappedDentalCleaning,
+      purpose: null,
+      lastVisitDate: formData.dentalHistory.lastDentalConsultation 
+        ? new Date(formData.dentalHistory.lastDentalConsultation).toISOString().split('T')[0]
+        : null
+    });
+    results.dentalHistory = dentalHistory;
+    console.log('[EMR Service] Dental history created:', dentalHistory);
+
+    // 11. Create Dental Procedure Profile (REQUIRED by backend)
+    console.log('[EMR Service] Creating empty dental procedure profile...');
+    const dentalProcedureProfile = await createDentalProcedureProfile({
+      procedures: [], // Empty - catalog IDs not available in form
+      notes: null
+    });
+    results.dentalProcedureProfile = dentalProcedureProfile;
+    console.log('[EMR Service] Dental procedure profile created:', dentalProcedureProfile);
+
+    // 12. Create Oral Appliance Profile (REQUIRED by backend)
+    console.log('[EMR Service] Creating empty oral appliance profile...');
+    const oralApplianceProfile = await createOralApplianceProfile({
+      appliances: [], // Empty - catalog IDs not available in form
+      notes: null
+    });
+    results.oralApplianceProfile = oralApplianceProfile;
+    console.log('[EMR Service] Oral appliance profile created:', oralApplianceProfile);
+
+    // 13. Create OB-GYNE History (if female only)
+    if (formData.personalInfo.gender === 'Female' && formData.obgyne) {
+      console.log('[EMR Service] Creating OB-GYNE history...');
+      
+      // Use actual lastMenstrualPeriod from form, or default to today
+      const lmpDate = formData.obgyne.lastMenstrualPeriod 
+        ? new Date(formData.obgyne.lastMenstrualPeriod).toISOString().split('T')[0]
+        : new Date().toISOString().split('T')[0];
+      
+      // Build notes from menstruation duration only (removed menarcheYearAge and padsPerDay)
+      const obgyneNotes = formData.obgyne.menstruationDuration 
+        ? `Duration: ${formData.obgyne.menstruationDuration} days`
+        : null;
+      
+      const obgyneHistory = await createObgynHistory({
+        lastMenstrualPeriod: lmpDate,
+        hasDysmenorrhea: formData.obgyne.dysmenorrhea === 'Yes',
+        notes: obgyneNotes
+      });
+      results.obgyneHistory = obgyneHistory;
+      console.log('[EMR Service] OB-GYNE history created:', obgyneHistory);
+    } else if (formData.personalInfo.gender === 'Female') {
+      console.log('[EMR Service] Creating default OB-GYNE history for female user...');
+      const obgyneHistory = await createObgynHistory({
+        lastMenstrualPeriod: new Date().toISOString().split('T')[0],
+        hasDysmenorrhea: false,
+        notes: null
+      });
+      results.obgyneHistory = obgyneHistory;
+      console.log('[EMR Service] Default OB-GYNE history created:', obgyneHistory);
+    } else {
+      console.log('[EMR Service] Skipping OB-GYNE history (not female)');
+    }
+
+    // Final Step: Submit the update ticket to finalize all changes
+    console.log('[EMR Service] Submitting update ticket to finalize changes...');
+    
+    try {
+      const submitStatus = await submitUpdateTicket();
+      results.submitStatus = submitStatus;
+      console.log('[EMR Service] Update ticket submitted with status:', submitStatus);
+    } catch (submitError) {
+      console.error('[EMR Service] Failed to submit update ticket:', submitError);
+      
+      // Check if error is due to missing staff-only records
+      if (submitError.message && submitError.message.includes('VitalSigns, MedicalHistory, Hospitalization')) {
+        console.error('='.repeat(80));
+        console.error('[EMR Service] BACKEND CONFIGURATION ERROR');
+        console.error('='.repeat(80));
+        console.error('The backend requires staff-only records (VitalSigns, DentalRecord, DentalPhotoRecord)');
+        console.error('for initial patient record submission. These cannot be created by patients.');
+        console.error('');
+        console.error('Backend team needs to fix this by either:');
+        console.error('1. Making these fields optional for initial records (scope="Both")');
+        console.error('2. Using separate Medical/Dental scopes for patient initial records');
+        console.error('3. Adding patient create mutations for these entities');
+        console.error('4. Auto-creating empty staff records when patient submits initial record');
+        console.error('='.repeat(80));
+      }
+      
+      throw submitError;
+    }
+
+    console.log('[EMR Service] Initial medical record creation completed successfully');
+    console.log('[EMR Service] All results:', results);
+
+    return {
+      success: true,
+      data: results
+    };
+
+  } catch (error) {
+    console.error('[EMR Service] Failed to create initial medical record:', error);
+    
+    // If ticket was created, try to cancel it
+    if (ticketCreated) {
+      console.log('[EMR Service] Attempting to cancel update ticket due to error...');
+      await cancelUpdateTicket();
+    }
+    
+    throw error;
+  }
+};
+
+// Individual mutation functions
+
+const createStudentProfile = async (input) => {
+  const mutation = `
+    mutation CreateStudentProfile($input: StudentProfileInput!) {
+      createStudentProfile(input: $input) {
+        id
+        program
+        year
+        guardian_name
+        guardian_relation
+        guardian_contact
+      }
+    }
+  `;
+  
+  const data = await sendGraphQLRequest(mutation, { input });
+  return data.createStudentProfile;
+};
+
+const createEmergencyContact = async (input) => {
+  const mutation = `
+    mutation CreateEmergencyContact($input: EmergencyContactInput!) {
+      createEmergencyContact(input: $input) {
+        id
+        firstContact {
+          id
+          contactName
+          relationship
+          contactNumber
+        }
+        secondContact {
+          id
+          contactName
+          relationship
+          contactNumber
+        }
+      }
+    }
+  `;
+  
+  const data = await sendGraphQLRequest(mutation, { input });
+  return data.createEmergencyContact;
+};
+
+const createMedicalHistory = async (input) => {
+  const mutation = `
+    mutation CreateMedicalHistory($input: MedicalHistoryInput!) {
+      createMedicalHistory(input: $input) {
+        id
+        conditions {
+          id
+          conditionId
+          relationship
+        }
+      }
+    }
+  `;
+  
+  const data = await sendGraphQLRequest(mutation, { input });
+  return data.createMedicalHistory;
+};
+
+const createAllergyProfile = async (input) => {
+  const mutation = `
+    mutation CreateAllergyProfile($input: AllergyProfileInput!) {
+      createAllergyProfile(input: $input) {
+        id
+        allergies {
+          id
+          allergenCatalogId
+          status
+          severity
+        }
+      }
+    }
+  `;
+  
+  const data = await sendGraphQLRequest(mutation, { input });
+  return data.createAllergyProfile;
+};
+
+const createHospitalizationProfile = async (input) => {
+  const mutation = `
+    mutation CreateHospitalizationProfile($input: HospitalizationProfileInput!) {
+      createHospitalizationProfile(input: $input) {
+        id
+        hospitalizations {
+          id
+          conditionId
+        }
+      }
+    }
+  `;
+  
+  const data = await sendGraphQLRequest(mutation, { input });
+  return data.createHospitalizationProfile;
+};
+
+const createOperationProfile = async (input) => {
+  const mutation = `
+    mutation CreateOperationProfile($input: OperationProfileInput!) {
+      createOperationProfile(input: $input) {
+        id
+        operations {
+          id
+          procedureId
+        }
+      }
+    }
+  `;
+  
+  const data = await sendGraphQLRequest(mutation, { input });
+  return data.createOperationProfile;
+};
+
+const createMedicationProfile = async (input) => {
+  const mutation = `
+    mutation CreateMedicationProfile($input: MedicationProfileInput!) {
+      createMedicationProfile(input: $input) {
+        id
+        medications {
+          id
+          medicineId
+        }
+      }
+    }
+  `;
+  
+  const data = await sendGraphQLRequest(mutation, { input });
+  return data.createMedicationProfile;
+};
+
+const createImmunizationProfile = async (input) => {
+  const mutation = `
+    mutation CreateImmunizationProfile($input: ImmunizationProfileInput!) {
+      createImmunizationProfile(input: $input) {
+        id
+        immunizations {
+          id
+          vaccineTypeId
+        }
+      }
+    }
+  `;
+  
+  const data = await sendGraphQLRequest(mutation, { input });
+  return data.createImmunizationProfile;
+};
+
+const createLifestyle = async (input) => {
+  const mutation = `
+    mutation CreateLifestyle($input: LifestyleInput!) {
+      createLifestyle(input: $input) {
+        id
+        smoker
+        alcoholConsumer
+      }
+    }
+  `;
+  
+  const data = await sendGraphQLRequest(mutation, { input });
+  return data.createLifestyle;
+};
+
+const createVisualAcuityProfile = async (input) => {
+  const mutation = `
+    mutation CreateVisualAcuityProfile($input: VisualAcuityProfileInput!) {
+      createVisualAcuityProfile(input: $input) {
+        id
+        acuity {
+          id
+          left_eye
+          right_eye
+        }
+      }
+    }
+  `;
+  
+  const data = await sendGraphQLRequest(mutation, { input });
+  return data.createVisualAcuityProfile;
+};
+
+const createDentalHistory = async (input) => {
+  const mutation = `
+    mutation CreateDentalHistory($input: DentalHistoryInput!) {
+      createDentalHistory(input: $input) {
+        id
+        seenByDentist
+        lastDentalCleaning
+      }
+    }
+  `;
+  
+  const data = await sendGraphQLRequest(mutation, { input });
+  return data.createDentalHistory;
+};
+
+const createDentalProcedureProfile = async (input) => {
+  const mutation = `
+    mutation CreateDentalProcedureProfile($input: DentalProcedureProfileInput!) {
+      createDentalProcedureProfile(input: $input) {
+        id
+        procedures {
+          id
+          procedureTypeId
+        }
+      }
+    }
+  `;
+  
+  const data = await sendGraphQLRequest(mutation, { input });
+  return data.createDentalProcedureProfile;
+};
+
+const createOralApplianceProfile = async (input) => {
+  const mutation = `
+    mutation CreateOralApplianceProfile($input: OralApplianceProfileInput!) {
+      createOralApplianceProfile(input: $input) {
+        id
+        appliances {
+          id
+          tagId
+        }
+      }
+    }
+  `;
+  
+  const data = await sendGraphQLRequest(mutation, { input });
+  return data.createOralApplianceProfile;
+};
+
+const createObgynHistory = async (input) => {
+  const mutation = `
+    mutation CreateObgynHistory($input: ObgynHistoryInput!) {
+      createObgynHistory(input: $input) {
+        id
+        lastMenstrualPeriod
+        hasDysmenorrhea
+      }
+    }
+  `;
+  
+  const data = await sendGraphQLRequest(mutation, { input });
+  return data.createObgynHistory;
+};
+
+// Utility function to map student category to year level
+const mapYearLevel = (category) => {
+  const mapping = {
+    'Freshmen': 'Freshman',
+    'Freshmen - New student': 'Freshman',
+    'Transferee': 'Sophomore',
+    'Graduate studies (New student)': 'Masteral',
+    'Graduate studies (Old student)': 'Masteral',
+    'Returnee': 'Sophomore',
+    'Old Student': 'Junior'
+  };
+  
+  return mapping[category] || 'Freshman';
+};
+
+// Utility function to map dental cleaning range to backend enum
+const mapDentalCleaningRange = (frontendValue) => {
+  const mapping = {
+    '0 to 6 months ago': '0-6',
+    '7 to 11 months ago': '7-12',
+    '1 year or more': '12-24',
+    '': '' // Empty string for not specified
+  };
+  
+  return mapping[frontendValue] || '';
+};
+
+export default {
+  createInitialMedicalRecord
+};

--- a/mds-frontend/src/services/emr-service.js
+++ b/mds-frontend/src/services/emr-service.js
@@ -794,6 +794,58 @@ const mapDentalCleaningRange = (frontendValue) => {
   return mapping[frontendValue] || '';
 };
 
+/**
+ * Check if the current user needs to complete their initial medical record
+ * Returns true if user needs to fill out the form (no approved record exists)
+ * Returns false if user has already completed their initial record
+ */
+export const checkInitialRecordStatus = async () => {
+  console.log('[EMR Service] Checking initial record status...');
+  
+  const query = `
+    query GetUpdateTicket {
+      getUpdateTicket {
+        id
+        status
+      }
+    }
+  `;
+  
+  try {
+    const data = await sendGraphQLRequest(query, {});
+    console.log('[EMR Service] Update ticket status:', data.getUpdateTicket);
+    
+    // If there's a ticket with status Pending, Approved, or RevisionSubmitted, they've completed the initial record
+    const ticket = data.getUpdateTicket;
+    
+    if (!ticket) {
+      // No ticket at all - needs to fill out initial record
+      console.log('[EMR Service] No update ticket found - initial record required');
+      return { needsInitialRecord: true, status: null };
+    }
+    
+    // Check if the status indicates they've completed the initial record
+    const completedStatuses = ['Pending', 'Approved', 'RevisionSubmitted'];
+    const needsInitialRecord = !completedStatuses.includes(ticket.status);
+    
+    console.log('[EMR Service] Initial record status:', { 
+      needsInitialRecord, 
+      currentStatus: ticket.status 
+    });
+    
+    return { 
+      needsInitialRecord, 
+      status: ticket.status,
+      ticketId: ticket.id
+    };
+  } catch (error) {
+    // If the query fails (e.g., no ticket exists), user needs to fill out the initial record
+    console.log('[EMR Service] Error checking status (likely no ticket):', error.message);
+    return { needsInitialRecord: true, status: null, error: error.message };
+  }
+};
+
 export default {
-  createInitialMedicalRecord
+  createInitialMedicalRecord,
+  checkInitialRecordStatus
 };

--- a/mds-frontend/src/utils/data-transformer.js
+++ b/mds-frontend/src/utils/data-transformer.js
@@ -1,0 +1,133 @@
+/**
+ * Data Transformer Utilities
+ * Transforms form data into backend-compatible formats
+ */
+
+/**
+ * Validates and logs the form data structure
+ */
+export const validateFormData = (formData) => {
+  console.log('[Data Transformer] Validating form data structure...');
+  
+  const validation = {
+    isValid: true,
+    errors: [],
+    warnings: []
+  };
+
+  // Check personal info
+  if (!formData.personalInfo) {
+    validation.errors.push('Missing personalInfo section');
+    validation.isValid = false;
+  } else {
+    if (!formData.personalInfo.surname) validation.errors.push('Missing surname');
+    if (!formData.personalInfo.firstName) validation.errors.push('Missing firstName');
+    if (!formData.personalInfo.birthday) validation.errors.push('Missing birthday');
+    if (!formData.personalInfo.gender) validation.errors.push('Missing gender');
+  }
+
+  // Check emergency contacts
+  if (!formData.personalInfo?.emergencyContacts || formData.personalInfo.emergencyContacts.length < 2) {
+    validation.errors.push('Need at least 2 emergency contacts');
+    validation.isValid = false;
+  }
+
+  // Check medical history
+  if (!formData.medicalHistory) {
+    validation.warnings.push('Missing medicalHistory section');
+  }
+
+  // Check medical background
+  if (!formData.medicalBackground) {
+    validation.warnings.push('Missing medicalBackground section');
+  }
+
+  // Check dental history
+  if (!formData.dentalHistory) {
+    validation.warnings.push('Missing dentalHistory section');
+  }
+
+  console.log('[Data Transformer] Validation result:', validation);
+  
+  return validation;
+};
+
+/**
+ * Sanitizes and prepares data for submission
+ */
+export const sanitizeFormData = (formData) => {
+  console.log('[Data Transformer] Sanitizing form data...');
+  
+  // Deep clone to avoid mutations
+  const sanitized = JSON.parse(JSON.stringify(formData));
+
+  // Ensure all required fields have values (even if empty)
+  if (!sanitized.personalInfo) sanitized.personalInfo = {};
+  if (!sanitized.medicalHistory) sanitized.medicalHistory = { self: {}, family: {} };
+  if (!sanitized.medicalBackground) sanitized.medicalBackground = {};
+  if (!sanitized.dentalHistory) sanitized.dentalHistory = {};
+  if (!sanitized.obgyne) sanitized.obgyne = {};
+  if (!sanitized.certification) sanitized.certification = {};
+
+  // Ensure emergency contacts array exists
+  if (!sanitized.personalInfo.emergencyContacts) {
+    sanitized.personalInfo.emergencyContacts = [
+      { name: '', relationship: '', contactNumber: '', address: '' },
+      { name: '', relationship: '', contactNumber: '', address: '' }
+    ];
+  }
+
+  // Convert string booleans to actual booleans
+  if (sanitized.medicalBackground.smoker === 'yes' || sanitized.medicalBackground.smoker === true) {
+    sanitized.medicalBackground.smoker = 'yes';
+  } else {
+    sanitized.medicalBackground.smoker = 'no';
+  }
+
+  if (sanitized.medicalBackground.alcoholDrinker === 'yes' || sanitized.medicalBackground.alcoholDrinker === true) {
+    sanitized.medicalBackground.alcoholDrinker = 'yes';
+  } else {
+    sanitized.medicalBackground.alcoholDrinker = 'no';
+  }
+
+  console.log('[Data Transformer] Sanitized data:', sanitized);
+  
+  return sanitized;
+};
+
+/**
+ * Formats dates to ISO format
+ */
+export const formatDate = (dateString) => {
+  if (!dateString) return null;
+  
+  try {
+    const date = new Date(dateString);
+    if (isNaN(date.getTime())) {
+      console.warn('[Data Transformer] Invalid date:', dateString);
+      return null;
+    }
+    return date.toISOString().split('T')[0];
+  } catch (error) {
+    console.error('[Data Transformer] Error formatting date:', dateString, error);
+    return null;
+  }
+};
+
+/**
+ * Debug helper to log the complete data structure
+ */
+export const logDataStructure = (data, label = 'Data Structure') => {
+  console.group(`[Data Transformer] ${label}`);
+  console.log('Type:', typeof data);
+  console.log('Keys:', Object.keys(data));
+  console.log('Full Object:', data);
+  console.groupEnd();
+};
+
+export default {
+  validateFormData,
+  sanitizeFormData,
+  formatDate,
+  logDataStructure
+};

--- a/mds-frontend/vite.config.js
+++ b/mds-frontend/vite.config.js
@@ -27,11 +27,12 @@ export default defineConfig(({ mode }) => {
     });
   }
   
-  // 🔧 DEVELOPER SWITCH: Change VITE_DEV_PORTAL in .env to 'www', 'www2', 'staff', or 'staff2'
+  // 🔧 DEVELOPER SWITCH: Change VITE_DEV_PORTAL in .env to 'www', 'www2', 'staff', 'staff2', or 'local'
   const DEV_PORTAL = env.VITE_DEV_PORTAL || 'www';
   
   // Determine backend URL based on DEV_PORTAL
   const PORTAL_URLS = {
+    local: 'http://localhost:3001',
     www: 'https://www.mdsystemtip.space',
     www2: 'https://www2.mdsystemtip.space',
     staff: 'https://staff.mdsystemtip.space',
@@ -39,6 +40,8 @@ export default defineConfig(({ mode }) => {
   };
   
   const BACKEND_URL = PORTAL_URLS[DEV_PORTAL] || PORTAL_URLS['www'];
+  
+  console.log(`🔗 Backend proxy target: ${BACKEND_URL} (DEV_PORTAL=${DEV_PORTAL})`);
 
   return {
     plugins: [
@@ -61,6 +64,11 @@ export default defineConfig(({ mode }) => {
           }
           // Proxy all other methods (POST, etc.) to backend
         },
+      },
+      '/emr': {
+        target: BACKEND_URL,
+        changeOrigin: true,
+        secure: true,
       },
       '/patient': {
         target: BACKEND_URL,


### PR DESCRIPTION
Title: feat(medical-record): convert initial medical record into modal form

Summary

Convert the initial medical record UI into a modal dialog to improve UX and reduce page clutter.
Adds form state handling, validation hooks, and save/cancel controls within a modal flow.
Changes

UI: initial medical record moved into a reusable modal component (open/close, focus trap).
Form: split into controlled inputs with simple client-side validation and clear error messaging.
UX: added Save and Cancel actions; Cancel discards unsaved changes; Save triggers existing persistence logic.
Accessibility: modal gets ARIA attributes and autofocus on first input when opened.
Minor: small styling adjustments to match existing design tokens.