### PR TITLE
FIX: fixed the frontend issue for staff portal login

### DIFF
--- a/mds-staff/vite.config.js
+++ b/mds-staff/vite.config.js
@@ -83,6 +83,11 @@ export default defineConfig(({ mode }) => {
           changeOrigin: true,
           secure: true,
         },
+        '/info': {
+          target: BACKEND_URL,
+          changeOrigin: true,
+          secure: true,
+        },
       },
     }
   }


### PR DESCRIPTION
The /info route was missing from the Vite proxy config. Added requests to /info/consent/login (and any other /info/* path) will now be correctly proxied to the backend.