### PR TITLE
Appointment — Scheduler CRUD & Server-side Rejection Acknowledge

### DIFF
--- a/Backend/routes/appointment/resolvers/patient/patient-resolver.js
+++ b/Backend/routes/appointment/resolvers/patient/patient-resolver.js
@@ -45,6 +45,10 @@ const Mutation = {
     return result;
   },
 
+  acknowledgeRejection: async (_, __, { user, res }) => {
+    return await Wrapper.Mutation._acknowledgeRejection(_, { patientId: user.id }, { user, res });
+  },
+
   cancelAppointment: async (_, __, { user, res }) => {
     const userRecord = await Wrapper.Query._getUserAppointmentRecords(_, { userId: user.id, offset: 0, limit: 1 }, { user, res });
 

--- a/Backend/routes/appointment/resolvers/wrapper/wrapper.js
+++ b/Backend/routes/appointment/resolvers/wrapper/wrapper.js
@@ -376,6 +376,21 @@ const Mutation = {
     return { ...psResult.rows[0], requirements: reqResult.rows };
   },
 
+  _acknowledgeRejection: async (_, { patientId }, { user, res }) => {
+    if (!user) {
+      throwGraphQLError(res).message("Unauthorized").status(401).throw();
+    }
+
+    const result = await db.query(
+      `UPDATE "patientSlot" SET "rejection_acknowledged" = true
+       WHERE "patientId" = $1 AND status = 'Rejected' AND "rejection_acknowledged" = false
+       RETURNING id;`,
+      [patientId]
+    );
+
+    return result.rowCount > 0;
+  },
+
   _cancelAppointment: async (_, { patientId, cancelledBy, slotId }, { user, res }) => {
     if (!user) {
       throwGraphQLError(res).message("Unauthorized").status(401).throw();

--- a/Backend/routes/appointment/schema.graphql
+++ b/Backend/routes/appointment/schema.graphql
@@ -137,6 +137,7 @@ type patientSlot {
   approvedBy: ID
   notes: String
   arrived_at: Date
+  rejection_acknowledged: Boolean
   created_at: Date!
 }
 
@@ -170,6 +171,7 @@ type Query {
 type Mutation {
   submitAppointment(schedulerId: ID!, date: Date!, session: SCHEDULE_SESSION!, requirements: [patientScheduleRequirementInput!]!): patientSlot
   cancelAppointment: Boolean
+  acknowledgeRejection: Boolean
 
   #----------- --^ Patient and --v Medical
   respondAppointment(userId: ID!, status: SCHEDULING_STATUS!, notes: String): patientSlot

--- a/mds-patient/src/modules/appointment/appointment.jsx
+++ b/mds-patient/src/modules/appointment/appointment.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import {
   STATUS,
   getAppointmentStatus,
+  acknowledgeRejection,
   listOpenAppointments,
   listRequirements,
   listCustomDates,
@@ -77,7 +78,7 @@ const PatientAppointment = () => {
 
       if (status === STATUS.REJECTED) {
         setRejectionRecord(record);
-        setRejectionAcknowledged(false);
+        setRejectionAcknowledged(!!record?.rejection_acknowledged);
         // Pre-load schedulers so the wizard is ready after the patient dismisses
         const list = await listOpenAppointments();
         setSchedulers(list);
@@ -261,7 +262,10 @@ const PatientAppointment = () => {
           </p>
 
           <button
-            onClick={() => setRejectionAcknowledged(true)}
+            onClick={async () => {
+              await acknowledgeRejection();
+              setRejectionAcknowledged(true);
+            }}
             className="px-5 py-2 bg-primary-600 hover:bg-primary-700 text-white font-medium rounded-lg transition-all"
           >
             OK, Book New Appointment

--- a/mds-patient/src/modules/appointment/patient-appointment-service.js
+++ b/mds-patient/src/modules/appointment/patient-appointment-service.js
@@ -48,11 +48,21 @@ export const getAppointmentStatus = async () => {
         status
         session
         notes
+        rejection_acknowledged
         created_at
       }
     }
   `);
   return data.getAppointmentStatus;
+};
+
+export const acknowledgeRejection = async () => {
+  const data = await sendGraphQL(`
+    mutation {
+      acknowledgeRejection
+    }
+  `);
+  return data.acknowledgeRejection;
 };
 
 /**

--- a/mds-patient/vite.config.js
+++ b/mds-patient/vite.config.js
@@ -90,6 +90,12 @@ export default defineConfig(({ mode }) => {
           target: BACKEND_URL,
           changeOrigin: true,
           secure: true,
+          bypass: function(req) {
+            // Don't proxy GET requests (browser navigation) - let React Router handle them
+            if (req.method === 'GET') {
+              return '/index.html';
+            }
+          },
         },
         '/media': {
           target: BACKEND_URL,

--- a/mds-staff/src/modules/appointment/components/availability-manager.jsx
+++ b/mds-staff/src/modules/appointment/components/availability-manager.jsx
@@ -2,7 +2,15 @@ import React, { useState, useEffect, useCallback } from 'react';
 import AvailabilityCalendar from './availability-calendar';
 import DaySlotEditor from './day-slot-editor';
 import EventModal from './event-modal';
-import { listAllSchedulers, updateDateIdentity } from '../staff-appointment-service';
+import SchedulerModal from './scheduler-modal';
+import {
+  listAllSchedulers,
+  createScheduler,
+  updateScheduler,
+  deleteScheduler,
+  updateRequirement,
+  updateDateIdentity,
+} from '../staff-appointment-service';
 
 /**
  * Availability Manager Component
@@ -19,6 +27,10 @@ const AvailabilityManager = () => {
   const [schedulers, setSchedulers] = useState([]);
   const [activeScheduler, setActiveScheduler] = useState(null);
   const [error, setError] = useState('');
+
+  // Scheduler modal
+  const [showSchedulerModal, setShowSchedulerModal] = useState(false);
+  const [editingScheduler, setEditingScheduler] = useState(null);
 
   // Derive slot defaults from the first active scheduler (or fallback)
   const slotDefaults = activeScheduler
@@ -83,6 +95,61 @@ const AvailabilityManager = () => {
 
   const handleDeleteEvent = (eventId) => {
     setEvents((prev) => prev.filter((e) => e.id !== eventId));
+  };
+
+  const handleOpenSchedulerModal = (scheduler = null) => {
+    setEditingScheduler(scheduler);
+    setShowSchedulerModal(true);
+  };
+
+  const handleSaveScheduler = async (formData, pendingReqs) => {
+    try {
+      if (formData.id) {
+        // Update existing
+        await updateScheduler(formData.id, {
+          label: formData.label,
+          location: formData.location,
+          schedulePerWeek: formData.schedulePerWeek,
+          morningAllowed: formData.morningAllowed,
+          afternoonAllowed: formData.afternoonAllowed,
+          notes: formData.notes || null,
+          isActive: formData.isActive,
+          whitelistOnly: formData.whitelistOnly,
+        });
+      } else {
+        // Create new
+        const created = await createScheduler({
+          label: formData.label,
+          location: formData.location,
+          schedulePerWeek: formData.schedulePerWeek,
+          morningAllowed: formData.morningAllowed,
+          afternoonAllowed: formData.afternoonAllowed,
+          notes: formData.notes || null,
+          whitelistOnly: formData.whitelistOnly ?? false,
+          slotCustomDates: [],
+          whiteLists: [],
+        });
+        // Save any pending requirements for the new scheduler
+        if (pendingReqs?.length > 0 && created?.id) {
+          for (const req of pendingReqs) {
+            await updateRequirement(created.id, { label: req.label, isDigital: true, isActive: true });
+          }
+        }
+      }
+      await loadSchedulers();
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const handleDeleteScheduler = async (schedulerId) => {
+    if (!window.confirm('Are you sure you want to delete this scheduler?')) return;
+    try {
+      await deleteScheduler(schedulerId);
+      await loadSchedulers();
+    } catch (err) {
+      setError(err.message);
+    }
   };
 
   return (
@@ -161,39 +228,36 @@ const AvailabilityManager = () => {
         </div>
       </div>
 
-      {/* Active Events List */}
+      {/* Active Schedulers List */}
       <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700">
         <div className="p-3 border-b border-neutral-200 dark:border-neutral-700 flex items-center justify-between">
-          <h3 className="text-sm font-semibold text-secondary-800 dark:text-white">Active Events</h3>
+          <h3 className="text-sm font-semibold text-secondary-800 dark:text-white">Active Schedulers</h3>
           <button
-            onClick={() => handleCreateEvent(null)}
+            onClick={() => handleOpenSchedulerModal(null)}
             className="inline-flex items-center gap-1 px-2.5 py-1 text-xs font-medium text-white bg-primary-500 hover:bg-primary-600 rounded-md transition-colors"
           >
             <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
             </svg>
-            New Event
+            New Scheduler
           </button>
         </div>
         <div className="divide-y divide-neutral-200 dark:divide-neutral-700">
-          {events.length > 0 ? (
-            events.map((event) => (
-              <div key={event.id} className="px-3 py-2 flex items-center justify-between hover:bg-neutral-50 dark:hover:bg-neutral-700/50 transition-colors">
+          {schedulers.length > 0 ? (
+            schedulers.map((sched) => (
+              <div key={sched.id} className="px-3 py-2 flex items-center justify-between hover:bg-neutral-50 dark:hover:bg-neutral-700/50 transition-colors">
                 <div className="flex items-center gap-2 min-w-0">
-                  <span className={`w-2 h-2 rounded-full flex-shrink-0 ${
-                    event.effect === 'Suspend' ? 'bg-error-500' : event.effect === 'Reduce' ? 'bg-warning-500' : 'bg-success-500'
-                  }`} />
-                  <span className="text-sm font-medium text-secondary-800 dark:text-white truncate">{event.name}</span>
+                  <span className={`w-2 h-2 rounded-full flex-shrink-0 ${sched.isActive ? 'bg-success-500' : 'bg-neutral-400'}`} />
+                  <span className="text-sm font-medium text-secondary-800 dark:text-white truncate">{sched.label}</span>
                   <span className="text-xs text-secondary-400 dark:text-neutral-500">·</span>
                   <span className="text-xs text-secondary-500 dark:text-neutral-400 whitespace-nowrap">
-                    {event.startDate === event.endDate ? event.startDate : `${event.startDate} → ${event.endDate}`}
-                    {' · '}{event.affects} · {event.effect}
-                    {event.recurrence !== 'None' && ` · ${event.recurrence}`}
+                    {sched.location} · AM {sched.morningAllowed} · PM {sched.afternoonAllowed}
+                    {sched.schedulePerWeek?.length > 0 && ` · ${sched.schedulePerWeek.map((d) => d.slice(0, 3)).join(', ')}`}
                   </span>
                 </div>
                 <div className="flex items-center gap-1 flex-shrink-0">
                   <button
-                    onClick={() => { setEditingEvent(event); setShowEventModal(true); }}
+                    onClick={() => handleOpenSchedulerModal(sched)}
                     className="p-1.5 text-secondary-400 hover:text-secondary-600 dark:text-neutral-500 dark:hover:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700 rounded transition-colors"
                     title="Edit"
                   >
@@ -202,7 +266,7 @@ const AvailabilityManager = () => {
                     </svg>
                   </button>
                   <button
-                    onClick={() => handleDeleteEvent(event.id)}
+                    onClick={() => handleDeleteScheduler(sched.id)}
                     className="p-1.5 text-error-400 hover:text-error-600 dark:text-error-500 dark:hover:text-error-400 hover:bg-error-50 dark:hover:bg-error-900/20 rounded transition-colors"
                     title="Delete"
                   >
@@ -215,8 +279,8 @@ const AvailabilityManager = () => {
             ))
           ) : (
             <div className="py-8 text-center">
-              <p className="text-sm text-secondary-500 dark:text-neutral-400">No active events</p>
-              <p className="text-xs text-secondary-400 dark:text-neutral-500 mt-1">Create events to override default schedules</p>
+              <p className="text-sm text-secondary-500 dark:text-neutral-400">No schedulers configured</p>
+              <p className="text-xs text-secondary-400 dark:text-neutral-500 mt-1">Create a scheduler to start managing appointments</p>
             </div>
           )}
         </div>
@@ -229,6 +293,15 @@ const AvailabilityManager = () => {
         onSave={handleSaveEvent}
         initialDate={eventModalDate}
         editingEvent={editingEvent}
+      />
+
+      {/* Scheduler Modal */}
+      <SchedulerModal
+        isOpen={showSchedulerModal}
+        onClose={() => { setShowSchedulerModal(false); setEditingScheduler(null); }}
+        onSave={handleSaveScheduler}
+        onDelete={handleDeleteScheduler}
+        editingScheduler={editingScheduler}
       />
     </div>
   );

--- a/mds-staff/src/modules/appointment/components/scheduler-modal.jsx
+++ b/mds-staff/src/modules/appointment/components/scheduler-modal.jsx
@@ -1,0 +1,329 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { listAllRequirements, updateRequirement, deleteRequirement } from '../staff-appointment-service';
+
+const DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+const LOCATIONS = ['Arlegui', 'Casal', 'QuezonCity'];
+
+const SchedulerModal = ({ isOpen, onClose, onSave, onDelete, editingScheduler }) => {
+  const isEditing = !!editingScheduler;
+
+  const [formData, setFormData] = useState(getDefaults(null));
+  const [requirements, setRequirements] = useState([]);
+  const [newReqLabel, setNewReqLabel] = useState('');
+  const [loadingReqs, setLoadingReqs] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  // Reset form when modal opens / scheduler changes
+  useEffect(() => {
+    if (isOpen) {
+      setFormData(getDefaults(editingScheduler));
+      setNewReqLabel('');
+      if (editingScheduler?.id) {
+        loadRequirements(editingScheduler.id);
+      } else {
+        setRequirements([]);
+      }
+    }
+  }, [isOpen, editingScheduler]);
+
+  const loadRequirements = useCallback(async (schedulerId) => {
+    setLoadingReqs(true);
+    try {
+      const reqs = await listAllRequirements(schedulerId);
+      setRequirements(reqs || []);
+    } catch {
+      setRequirements([]);
+    } finally {
+      setLoadingReqs(false);
+    }
+  }, []);
+
+  if (!isOpen) return null;
+
+  const handleChange = (field) => (e) => {
+    const value = e.target.type === 'number' ? parseInt(e.target.value, 10) || 0 : e.target.value;
+    setFormData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const toggleDay = (day) => {
+    setFormData((prev) => ({
+      ...prev,
+      schedulePerWeek: prev.schedulePerWeek.includes(day)
+        ? prev.schedulePerWeek.filter((d) => d !== day)
+        : [...prev.schedulePerWeek, day],
+    }));
+  };
+
+  const handleAddRequirement = async () => {
+    const label = newReqLabel.trim();
+    if (!label) return;
+
+    if (isEditing && editingScheduler?.id) {
+      try {
+        const req = await updateRequirement(editingScheduler.id, { label, isDigital: true, isActive: true });
+        setRequirements((prev) => [...prev, req]);
+      } catch { /* requirement might already exist */ }
+    } else {
+      // For new schedulers, track locally (saved after scheduler creation)
+      setRequirements((prev) => [...prev, { id: `local-${Date.now()}`, label, isDigital: true, isActive: true }]);
+    }
+    setNewReqLabel('');
+  };
+
+  const handleRemoveRequirement = async (req) => {
+    if (isEditing && editingScheduler?.id && !String(req.id).startsWith('local-')) {
+      try {
+        await deleteRequirement(editingScheduler.id, req.label);
+      } catch { /* ignore */ }
+    }
+    setRequirements((prev) => prev.filter((r) => r.id !== req.id));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!formData.label.trim() || formData.schedulePerWeek.length === 0) return;
+
+    setSaving(true);
+    try {
+      // Collect pending local requirements (for new schedulers)
+      const pendingReqs = requirements.filter((r) => String(r.id).startsWith('local-'));
+      await onSave?.({ ...formData, id: editingScheduler?.id }, pendingReqs);
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white dark:bg-neutral-800 rounded-xl shadow-2xl max-w-lg w-full max-h-[90vh] overflow-y-auto">
+        {/* Header */}
+        <div className="px-5 py-4 border-b border-neutral-200 dark:border-neutral-700 flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-bold text-secondary-900 dark:text-white">
+              {isEditing ? 'Edit Scheduler' : 'New Scheduler'}
+            </h2>
+            <p className="text-xs text-secondary-500 dark:text-neutral-400 mt-0.5">
+              {isEditing ? 'Modify scheduler settings and requirements' : 'Create a new appointment scheduler'}
+            </p>
+          </div>
+          <button onClick={onClose} className="p-2 hover:bg-neutral-100 dark:hover:bg-neutral-700 rounded-lg transition-colors">
+            <svg className="w-5 h-5 text-secondary-600 dark:text-neutral-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="p-5 space-y-4">
+          {/* Label */}
+          <div>
+            <label className="text-xs font-medium text-secondary-600 dark:text-neutral-300 mb-1.5 block">Label</label>
+            <input
+              type="text"
+              value={formData.label}
+              onChange={handleChange('label')}
+              placeholder="e.g., Medical Consultation"
+              required
+              className="w-full px-3 py-2 text-sm bg-neutral-50 dark:bg-neutral-700 border border-neutral-200 dark:border-neutral-600 rounded-md text-secondary-800 dark:text-white placeholder-secondary-400 dark:placeholder-neutral-500 focus:outline-none focus:ring-1 focus:ring-primary-500 focus:border-primary-500"
+            />
+          </div>
+
+          {/* Location */}
+          <div>
+            <label className="text-xs font-medium text-secondary-600 dark:text-neutral-300 mb-1.5 block">Location</label>
+            <div className="flex gap-2">
+              {LOCATIONS.map((loc) => (
+                <button
+                  key={loc}
+                  type="button"
+                  onClick={() => setFormData((prev) => ({ ...prev, location: loc }))}
+                  className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
+                    formData.location === loc
+                      ? 'bg-primary-500 text-white'
+                      : 'bg-neutral-100 dark:bg-neutral-700 text-secondary-600 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-600'
+                  }`}
+                >
+                  {loc}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Schedule Days */}
+          <div>
+            <label className="text-xs font-medium text-secondary-600 dark:text-neutral-300 mb-1.5 block">Schedule Days</label>
+            <div className="flex flex-wrap gap-1.5">
+              {DAYS.map((day) => (
+                <button
+                  key={day}
+                  type="button"
+                  onClick={() => toggleDay(day)}
+                  className={`px-2.5 py-1 text-xs font-medium rounded-md transition-colors ${
+                    formData.schedulePerWeek.includes(day)
+                      ? 'bg-accent-500 text-white'
+                      : 'bg-neutral-100 dark:bg-neutral-700 text-secondary-500 dark:text-neutral-400 hover:bg-neutral-200 dark:hover:bg-neutral-600'
+                  }`}
+                >
+                  {day.slice(0, 3)}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Slot Counts */}
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="text-[10px] text-secondary-500 dark:text-neutral-400 mb-1 block uppercase tracking-wider">Morning Slots</label>
+              <input
+                type="number"
+                value={formData.morningAllowed}
+                onChange={handleChange('morningAllowed')}
+                min={0}
+                className="w-full px-3 py-1.5 text-sm bg-neutral-50 dark:bg-neutral-700 border border-neutral-200 dark:border-neutral-600 rounded-md text-secondary-800 dark:text-white focus:outline-none focus:ring-1 focus:ring-primary-500"
+              />
+            </div>
+            <div>
+              <label className="text-[10px] text-secondary-500 dark:text-neutral-400 mb-1 block uppercase tracking-wider">Afternoon Slots</label>
+              <input
+                type="number"
+                value={formData.afternoonAllowed}
+                onChange={handleChange('afternoonAllowed')}
+                min={0}
+                className="w-full px-3 py-1.5 text-sm bg-neutral-50 dark:bg-neutral-700 border border-neutral-200 dark:border-neutral-600 rounded-md text-secondary-800 dark:text-white focus:outline-none focus:ring-1 focus:ring-primary-500"
+              />
+            </div>
+          </div>
+
+          {/* Notes */}
+          <div>
+            <label className="text-xs font-medium text-secondary-600 dark:text-neutral-300 mb-1.5 block">Notes (Optional)</label>
+            <textarea
+              value={formData.notes}
+              onChange={handleChange('notes')}
+              rows={2}
+              placeholder="Additional details..."
+              className="w-full px-3 py-2 text-sm bg-neutral-50 dark:bg-neutral-700 border border-neutral-200 dark:border-neutral-600 rounded-md text-secondary-800 dark:text-white placeholder-secondary-400 dark:placeholder-neutral-500 focus:outline-none focus:ring-1 focus:ring-primary-500 resize-none"
+            />
+          </div>
+
+          {/* Active toggle (edit only) */}
+          {isEditing && (
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={formData.isActive}
+                onChange={(e) => setFormData((prev) => ({ ...prev, isActive: e.target.checked }))}
+                className="w-4 h-4 rounded border-neutral-300 text-primary-500 focus:ring-primary-500"
+              />
+              <span className="text-sm text-secondary-700 dark:text-neutral-300">Active</span>
+            </label>
+          )}
+
+          {/* ── Requirements ───────────────────────────────────────────── */}
+          <div className="border border-neutral-200 dark:border-neutral-700 rounded-lg overflow-hidden">
+            <div className="bg-neutral-50 dark:bg-neutral-800/50 px-4 py-2.5 border-b border-neutral-200 dark:border-neutral-700 flex items-center justify-between">
+              <h3 className="text-xs font-semibold text-secondary-800 dark:text-white uppercase tracking-wide">Requirements</h3>
+              <span className="text-[10px] text-secondary-400 dark:text-neutral-500">{requirements.length} items</span>
+            </div>
+
+            {/* List */}
+            <div className="divide-y divide-neutral-100 dark:divide-neutral-700">
+              {loadingReqs ? (
+                <div className="px-4 py-3 text-xs text-secondary-400 dark:text-neutral-500">Loading...</div>
+              ) : requirements.length > 0 ? (
+                requirements.map((req) => (
+                  <div key={req.id} className="px-4 py-2 flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-2 min-w-0">
+                      <svg className="w-4 h-4 text-primary-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                      </svg>
+                      <span className="text-sm text-secondary-700 dark:text-neutral-300 truncate">{req.label}</span>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveRequirement(req)}
+                      className="p-1 text-error-400 hover:text-error-600 dark:text-error-500 dark:hover:text-error-400 hover:bg-error-50 dark:hover:bg-error-900/20 rounded transition-colors flex-shrink-0"
+                      title="Remove requirement"
+                    >
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                      </svg>
+                    </button>
+                  </div>
+                ))
+              ) : (
+                <div className="px-4 py-3 text-xs text-secondary-400 dark:text-neutral-500">No requirements yet</div>
+              )}
+            </div>
+
+            {/* Add requirement */}
+            <div className="px-4 py-2.5 border-t border-neutral-200 dark:border-neutral-700 flex gap-2">
+              <input
+                type="text"
+                value={newReqLabel}
+                onChange={(e) => setNewReqLabel(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); handleAddRequirement(); } }}
+                placeholder="e.g., Certificate of Employment"
+                className="flex-1 px-3 py-1.5 text-sm bg-neutral-50 dark:bg-neutral-700 border border-neutral-200 dark:border-neutral-600 rounded-md text-secondary-800 dark:text-white placeholder-secondary-400 dark:placeholder-neutral-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+              />
+              <button
+                type="button"
+                onClick={handleAddRequirement}
+                disabled={!newReqLabel.trim()}
+                className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-white bg-primary-500 hover:bg-primary-600 rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                </svg>
+                Add
+              </button>
+            </div>
+          </div>
+
+          {/* Action Buttons */}
+          <div className="flex gap-2 pt-2 border-t border-neutral-200 dark:border-neutral-700">
+            {isEditing && onDelete && (
+              <button
+                type="button"
+                onClick={() => { onDelete(editingScheduler.id); onClose(); }}
+                className="px-4 py-2 text-sm font-medium text-error-600 dark:text-error-400 bg-error-50 dark:bg-error-900/20 hover:bg-error-100 dark:hover:bg-error-900/30 rounded-md transition-colors"
+              >
+                Delete
+              </button>
+            )}
+            <div className="flex-1" />
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm font-medium text-secondary-600 dark:text-neutral-300 bg-neutral-100 dark:bg-neutral-700 hover:bg-neutral-200 dark:hover:bg-neutral-600 rounded-md transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={saving}
+              className="px-4 py-2 text-sm font-medium text-white bg-primary-500 hover:bg-primary-600 rounded-md transition-colors disabled:opacity-50"
+            >
+              {saving ? 'Saving...' : isEditing ? 'Update' : 'Create'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+function getDefaults(scheduler) {
+  return {
+    label: scheduler?.label || '',
+    location: scheduler?.location || 'Arlegui',
+    schedulePerWeek: scheduler?.schedulePerWeek || ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+    morningAllowed: scheduler?.morningAllowed ?? 20,
+    afternoonAllowed: scheduler?.afternoonAllowed ?? 15,
+    notes: scheduler?.notes || '',
+    isActive: scheduler?.isActive ?? true,
+    whitelistOnly: scheduler?.whitelistOnly ?? false,
+  };
+}
+
+export default SchedulerModal;

--- a/mds-staff/vite.config.js
+++ b/mds-staff/vite.config.js
@@ -78,6 +78,12 @@ export default defineConfig(({ mode }) => {
           target: BACKEND_URL,
           changeOrigin: true,
           secure: true,
+          bypass: function(req) {
+            // Don't proxy GET requests (browser navigation) - let React Router handle them
+            if (req.method === 'GET') {
+              return '/index.html';
+            }
+          },
         },
         '/profile': {
           target: BACKEND_URL,


### PR DESCRIPTION
# Appointment — Scheduler CRUD & Server-side Rejection Acknowledge

Summary
- Show schedulers in Staff Availability (create/edit/delete).
- Add requirements management to scheduler modal (add/remove requirement labels).
- Replace client-only rejection acknowledgement with a server-side mutation and DB flag so patient dismissal persists across devices/sessions.

What changed
- Frontend (staff):
  - mds-staff/src/modules/appointment/components/scheduler-modal.jsx — new modal for create/edit schedulers and requirements
  - mds-staff/src/modules/appointment/components/availability-manager.jsx — show `slotScheduler` records as "Active Schedulers" and wire CRUD handlers

- Frontend (patient):
  - mds-patient/src/modules/appointment/appointment.jsx — use `rejection_acknowledged` from server; call `acknowledgeRejection()` mutation on dismiss
  - mds-patient/src/modules/appointment/patient-appointment-service.js — added `acknowledgeRejection` mutation and include `rejection_acknowledged` in `getAppointmentStatus`

- Backend:
  - Backend/commands/MDSystem030726.sql — added `rejection_acknowledged` boolean column to `patientSlot` (default false)
  - Backend/routes/appointment/schema.graphql — `patientSlot` now exposes `rejection_acknowledged`; new `acknowledgeRejection` mutation
  - Backend/routes/appointment/resolvers/wrapper/wrapper.js — added `_acknowledgeRejection` mutation to set the flag
  - Backend/routes/appointment/resolvers/patient/patient-resolver.js — exposed `acknowledgeRejection` mutation

Behavior / UX
- Staff: schedulers seeded via post-build SQL (Medical/Dental entries) appear in Availability → Active Schedulers and can be edited or deleted. Requirements can be added with the + input and are saved to the scheduler.
- Patient: when staff rejects an appointment, the patient sees the rejection notice once. Dismissing it calls the server mutation which persists acknowledgement; the notice will not reappear on refresh, logout/login, or other devices.

DB Migration
- Run the one-line migration on the production DB:

```sql
ALTER TABLE "patientSlot" ADD COLUMN IF NOT EXISTS "rejection_acknowledged" boolean DEFAULT false;
```

Testing checklist
- Staff
  - Open Availability → confirm schedulers list includes seeded schedulers.
  - Create a scheduler, add a requirement via the + input, save — confirm requirement appears in `listAllAppointmentRequirements`.
  - Edit a scheduler and remove a requirement.

- Patient
  - Have staff reject a patient's appointment (use Respond → Rejected with notes).
  - As the patient, open Appointments: rejection card appears with notes.
  - Click "OK, Book New Appointment" — confirm API mutation `acknowledgeRejection` is called and subsequent refresh hides the card.

Rollback
- Revert frontend commits and remove DB column (if needed):

```sql
ALTER TABLE "patientSlot" DROP COLUMN IF EXISTS "rejection_acknowledged";
```

Notes
- Files/uploads for requirements use the existing `appointment_requirements` media path and the backend `promoteFile` flow; no change required to file storage layout.
