### PR TITLE
Appointment — Staff Scheduler fixes, requirement validation, and Patient Lookup

### DIFF
--- a/Backend/routes/appointment/resolvers/medical/medical-resolver.js
+++ b/Backend/routes/appointment/resolvers/medical/medical-resolver.js
@@ -27,6 +27,14 @@ const Query = {
     return await Wrapper.Query._getUserAppointmentRecords(_, { userId, offset, limit }, { user, res });
   },
 
+  resolvePatientByIdentifier: async (_, { identifier }, { user, res }) => {
+    const permitted = await permit.isMedicalPermitted(user.id, permit.permissions.appointment_allow_view_records, null);
+    if (!permitted) {
+      throwGraphQLError(res).message("Unauthorized").status(401).throw();
+    }
+    return await Wrapper.Query._resolvePatientByIdentifier(_, { identifier }, { user, res });
+  },
+
   listAllOpenAppointments: async (_, { offset, limit }, { user, res }) => {
     const permitted = await permit.isMedicalPermitted(user.id, permit.permissions.appointment_allow_view_configuration, null);
     if (!permitted) {

--- a/Backend/routes/appointment/resolvers/wrapper/helper.js
+++ b/Backend/routes/appointment/resolvers/wrapper/helper.js
@@ -129,12 +129,13 @@ async function validateSatisfiedAllRequirements(scheduleId, requirements, res) {
     [scheduleId]
   );
 
-  const requiredIds = result.rows.map(r => r.id);
+  const requiredIds = result.rows.map(r => String(r.id));
 
   // Extract provided IDs from array of patientScheduleRequirement objects
   const providedIds = (requirements || [])
     .map(r => r.scheduleRequirementId)
-    .filter(id => id != null);
+    .filter(id => id != null)
+    .map(id => String(id));
 
   // Case: no requirements defined in DB
   if (requiredIds.length === 0) {

--- a/Backend/routes/appointment/resolvers/wrapper/wrapper.js
+++ b/Backend/routes/appointment/resolvers/wrapper/wrapper.js
@@ -203,10 +203,13 @@ const Query = {
       throwGraphQLError(res).message("Unauthorized").status(401).throw();
     }
 
-    // Fetch the patient slots
+    // Fetch the patient slots (with identifier + name from UsersPersonal)
     const querySlots = `
-      SELECT ps.*
+      SELECT ps.*,
+        up."identifier" AS "patientIdentifier",
+        CONCAT(up.first_name, ' ', up.last_name) AS "patientName"
       FROM "patientSlot" ps
+      LEFT JOIN "UsersPersonal" up ON up.id = ps."patientId"
       WHERE ps."patientId" = $1
       ORDER BY ps.id DESC
       LIMIT $2 OFFSET $3;
@@ -268,6 +271,18 @@ const Query = {
       return null; // No appointments found
     }
     return result.rows[0].status;
+  },
+
+  _resolvePatientByIdentifier: async (_, { identifier }, { user, res }) => {
+    if (!user) {
+      throwGraphQLError(res).message("Unauthorized").status(401).throw();
+    }
+    const result = await db.query(
+      `SELECT id FROM "UsersPersonal" WHERE identifier = $1 LIMIT 1;`,
+      [identifier]
+    );
+    if (result.rowCount === 0) return null;
+    return String(result.rows[0].id);
   },
 
   _searchAppointmentStatuses: async (_, { status, offset, limit }, { user, res }) => {
@@ -633,6 +648,28 @@ const Mutation = {
     if (!user) {
       throwGraphQLError(res).message("Unauthorized").status(401).throw();
     }
+
+    // Refuse deletion if any appointment records reference this scheduler's date entities
+    const slotCheck = await db.query(
+      `SELECT 1 FROM "patientSlot" ps
+       INNER JOIN "ScheduleDateEntity" sde ON sde.id = ps."slotEntityId"
+       WHERE sde."slotId" = $1
+       LIMIT 1;`,
+      [schedulerId]
+    );
+
+    if (slotCheck.rowCount > 0) {
+      throwGraphQLError(res)
+        .message("Cannot delete scheduler: it has associated appointment records. Deactivate it instead.")
+        .status(400)
+        .throw();
+    }
+
+    // Cascade delete child records in FK-safe order before deleting the scheduler
+    await db.query(`DELETE FROM "schedulerWhitelist" WHERE "slotSchedulerId" = $1;`, [schedulerId]);
+    await db.query(`DELETE FROM "scheduleRequirement" WHERE "slotId" = $1;`, [schedulerId]);
+    await db.query(`DELETE FROM "SlotCustomDate" WHERE "slotScheduleId" = $1;`, [schedulerId]);
+    await db.query(`DELETE FROM "ScheduleDateEntity" WHERE "slotId" = $1;`, [schedulerId]);
 
     const result = await db.query(
       `DELETE FROM "slotScheduler" WHERE id = $1;`,

--- a/Backend/routes/appointment/schema.graphql
+++ b/Backend/routes/appointment/schema.graphql
@@ -160,6 +160,7 @@ type Query {
   getUserAppointmentStatus(userId: ID!): SCHEDULING_STATUS
 
   getUserAppointmentRecords(userId: ID!, offset: Int, limit: Int): [patientSlot!]
+  resolvePatientByIdentifier(identifier: Int!): ID
 
   listAllOpenAppointments(offset: Int, limit: Int): [SlotScheduler!]
   listAllAppointmentRequirements(schedulerId: ID!, offset: Int, limit: Int): [ScheduleRequirement!]

--- a/mds-staff/src/modules/appointment/components/appointment-detail-modal.jsx
+++ b/mds-staff/src/modules/appointment/components/appointment-detail-modal.jsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
+import { getPatientStatus, getPatientRecords } from '../staff-appointment-service';
 
 /**
  * Appointment Detail Modal
@@ -11,15 +12,56 @@ import React, { useState } from 'react';
  *   Scheduled   → Record Attendance (InProgress), Cancel (CancelledByMedical), No-Show
  *   InProgress  → Complete, No-Show
  */
+const STATUS_COLORS = {
+  Pending:            'bg-warning-100 dark:bg-warning-900/30 text-warning-700 dark:text-warning-400',
+  Scheduled:          'bg-accent-100  dark:bg-accent-900/30  text-accent-700  dark:text-accent-400',
+  InProgress:         'bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-400',
+  Completed:          'bg-success-100 dark:bg-success-900/30 text-success-700 dark:text-success-400',
+  Rejected:           'bg-error-100   dark:bg-error-900/30   text-error-700   dark:text-error-400',
+  CancelledByPatient: 'bg-error-100   dark:bg-error-900/30   text-error-700   dark:text-error-400',
+  CancelledByMedical: 'bg-error-100   dark:bg-error-900/30   text-error-700   dark:text-error-400',
+  NoShow:             'bg-warning-100 dark:bg-warning-900/30 text-warning-700 dark:text-warning-400',
+  Expired:            'bg-neutral-100 dark:bg-neutral-700     text-neutral-500 dark:text-neutral-400',
+};
+
 const AppointmentDetailModal = ({ appointment, onClose, onConfirm, onCancel, onMarkDone, onMarkNoShow, onMarkComplete }) => {
   const [showCancelForm, setShowCancelForm] = useState(false);
   const [cancelReason, setCancelReason] = useState('');
+  const [history, setHistory] = useState([]);
+  const [historyStatus, setHistoryStatus] = useState(null);
+  const [historyLoading, setHistoryLoading] = useState(false);
+
+  const loadHistory = useCallback(async (pid) => {
+    setHistoryLoading(true);
+    try {
+      const [status, records] = await Promise.all([
+        getPatientStatus(pid),
+        getPatientRecords(pid, 0, 10),
+      ]);
+      setHistoryStatus(status);
+      setHistory(records || []);
+    } catch {
+      // non-critical — history panel stays empty
+    } finally {
+      setHistoryLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (appointment?.patientId) {
+      setHistory([]);
+      setHistoryStatus(null);
+      loadHistory(appointment.patientId);
+    }
+  }, [appointment?.patientId, loadHistory]);
 
   if (!appointment) return null;
 
   const {
     id,
     patientId,
+    patientIdentifier,
+    patientName,
     slotEntityId,
     status,
     session,
@@ -67,17 +109,7 @@ const AppointmentDetailModal = ({ appointment, onClose, onConfirm, onCancel, onM
     onClose();
   };
 
-  const statusColors = {
-    Pending:            'bg-warning-100 dark:bg-warning-900/30 text-warning-700 dark:text-warning-400',
-    Scheduled:          'bg-accent-100  dark:bg-accent-900/30  text-accent-700  dark:text-accent-400',
-    InProgress:         'bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-400',
-    Completed:          'bg-success-100 dark:bg-success-900/30 text-success-700 dark:text-success-400',
-    Rejected:           'bg-error-100   dark:bg-error-900/30   text-error-700   dark:text-error-400',
-    CancelledByPatient: 'bg-error-100   dark:bg-error-900/30   text-error-700   dark:text-error-400',
-    CancelledByMedical: 'bg-error-100   dark:bg-error-900/30   text-error-700   dark:text-error-400',
-    NoShow:             'bg-warning-100 dark:bg-warning-900/30 text-warning-700 dark:text-warning-400',
-    Expired:            'bg-neutral-100 dark:bg-neutral-700     text-neutral-500 dark:text-neutral-400',
-  };
+  const statusColors = STATUS_COLORS;
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
@@ -86,7 +118,17 @@ const AppointmentDetailModal = ({ appointment, onClose, onConfirm, onCancel, onM
         <div className="sticky top-0 bg-white dark:bg-neutral-800 px-5 py-4 border-b border-neutral-200 dark:border-neutral-700 flex items-center justify-between z-10">
           <div>
             <h2 className="text-lg font-bold text-secondary-900 dark:text-white">Appointment #{id}</h2>
-            <p className="text-xs text-secondary-500 dark:text-neutral-400">Patient: {patientId}</p>
+            <div className="flex items-center gap-2 mt-0.5">
+              <p className="text-xs text-secondary-500 dark:text-neutral-400">
+                  Patient: {patientName ? `${patientName} ` : ''}
+                  {patientIdentifier ? `ID ${patientIdentifier}` : `(uid ${patientId})`}
+                </p>
+              {historyStatus && (
+                <span className={`px-1.5 py-0.5 text-[10px] font-medium rounded ${STATUS_COLORS[historyStatus] || 'bg-neutral-100 text-neutral-600'}`}>
+                  Latest: {historyStatus}
+                </span>
+              )}
+            </div>
           </div>
           <div className="flex items-center gap-2">
             <span className={`px-2.5 py-1 text-xs font-medium rounded-md ${statusColors[status] || 'bg-neutral-100 text-neutral-600'}`}>
@@ -112,7 +154,8 @@ const AppointmentDetailModal = ({ appointment, onClose, onConfirm, onCancel, onM
             </div>
             <div className="p-4 grid grid-cols-2 md:grid-cols-3 gap-3">
               {[
-                { label: 'Patient ID', value: patientId },
+                { label: 'Student / Employee ID', value: patientIdentifier ?? '—' },
+                { label: 'Internal User ID', value: patientId },
                 { label: 'Session', value: session },
                 { label: 'Status', value: status },
                 { label: 'Slot Entity', value: slotEntityId },
@@ -163,6 +206,40 @@ const AppointmentDetailModal = ({ appointment, onClose, onConfirm, onCancel, onM
               </div>
             </div>
           )}
+
+          {/* Patient History */}
+          <div className="border border-neutral-200 dark:border-neutral-700 rounded-lg overflow-hidden">
+            <div className="bg-neutral-50 dark:bg-neutral-800/50 px-4 py-2.5 border-b border-neutral-200 dark:border-neutral-700 flex items-center justify-between">
+              <h3 className="text-xs font-semibold text-secondary-800 dark:text-white uppercase tracking-wide">Patient Appointment History</h3>
+              <span className="text-[10px] text-secondary-400 dark:text-neutral-500">{history.length} record{history.length !== 1 ? 's' : ''}</span>
+            </div>
+            <div className="divide-y divide-neutral-100 dark:divide-neutral-700/60">
+              {historyLoading ? (
+                <div className="px-4 py-3 text-xs text-secondary-400 dark:text-neutral-500">Loading history...</div>
+              ) : history.length === 0 ? (
+                <div className="px-4 py-3 text-xs text-secondary-400 dark:text-neutral-500">No past appointments found.</div>
+              ) : (
+                history.map((rec) => (
+                  <div key={rec.id} className={`px-4 py-2.5 flex items-center justify-between gap-3 ${rec.id === id ? 'bg-primary-50 dark:bg-primary-900/10' : ''}`}>
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-1.5">
+                        <span className="text-xs font-medium text-secondary-700 dark:text-neutral-300">#{rec.id}</span>
+                        {rec.id === id && <span className="text-[10px] text-primary-600 dark:text-primary-400 font-semibold">current</span>}
+                        <span className="text-[10px] text-secondary-400 dark:text-neutral-500">{rec.session}</span>
+                      </div>
+                      <p className="text-[10px] text-secondary-400 dark:text-neutral-500 mt-0.5">
+                        {rec.created_at ? new Date(rec.created_at).toLocaleDateString() : '—'}
+                        {rec.notes ? ` · ${rec.notes}` : ''}
+                      </p>
+                    </div>
+                    <span className={`px-2 py-0.5 text-[10px] font-medium rounded whitespace-nowrap ${STATUS_COLORS[rec.status] || 'bg-neutral-100 text-neutral-600'}`}>
+                      {rec.status}
+                    </span>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
 
           {/* Cancel Form */}
           {showCancelForm && (

--- a/mds-staff/src/modules/appointment/components/availability-manager.jsx
+++ b/mds-staff/src/modules/appointment/components/availability-manager.jsx
@@ -40,12 +40,15 @@ const AvailabilityManager = () => {
       }
     : { medical: { morning: 60, afternoon: 60 }, dental: { morning: 1, afternoon: 1 } };
 
-  // Load schedulers from API
-  const loadSchedulers = useCallback(async () => {
+  // Load schedulers from API — preserves the currently selected scheduler if it still exists
+  const loadSchedulers = useCallback(async (preserveId = null) => {
     try {
       const list = await listAllSchedulers();
       setSchedulers(list || []);
-      if (list?.length > 0) setActiveScheduler(list[0]);
+      if (list?.length > 0) {
+        const kept = preserveId ? list.find((s) => String(s.id) === String(preserveId)) : null;
+        setActiveScheduler(kept || list[0]);
+      }
     } catch (err) {
       setError(err.message);
     }
@@ -103,42 +106,39 @@ const AvailabilityManager = () => {
   };
 
   const handleSaveScheduler = async (formData, pendingReqs) => {
-    try {
-      if (formData.id) {
-        // Update existing
-        await updateScheduler(formData.id, {
-          label: formData.label,
-          location: formData.location,
-          schedulePerWeek: formData.schedulePerWeek,
-          morningAllowed: formData.morningAllowed,
-          afternoonAllowed: formData.afternoonAllowed,
-          notes: formData.notes || null,
-          isActive: formData.isActive,
-          whitelistOnly: formData.whitelistOnly,
-        });
-      } else {
-        // Create new
-        const created = await createScheduler({
-          label: formData.label,
-          location: formData.location,
-          schedulePerWeek: formData.schedulePerWeek,
-          morningAllowed: formData.morningAllowed,
-          afternoonAllowed: formData.afternoonAllowed,
-          notes: formData.notes || null,
-          whitelistOnly: formData.whitelistOnly ?? false,
-          slotCustomDates: [],
-          whiteLists: [],
-        });
-        // Save any pending requirements for the new scheduler
-        if (pendingReqs?.length > 0 && created?.id) {
-          for (const req of pendingReqs) {
-            await updateRequirement(created.id, { label: req.label, isDigital: true, isActive: true });
-          }
+    if (formData.id) {
+      // Update existing — re-throws so the modal stays open on failure
+      const updated = await updateScheduler(formData.id, {
+        label: formData.label,
+        location: formData.location,
+        schedulePerWeek: formData.schedulePerWeek,
+        morningAllowed: formData.morningAllowed,
+        afternoonAllowed: formData.afternoonAllowed,
+        notes: formData.notes || null,
+        isActive: formData.isActive,
+        whitelistOnly: formData.whitelistOnly,
+      });
+      await loadSchedulers(updated?.id ?? formData.id);
+    } else {
+      // Create new
+      const created = await createScheduler({
+        label: formData.label,
+        location: formData.location,
+        schedulePerWeek: formData.schedulePerWeek,
+        morningAllowed: formData.morningAllowed,
+        afternoonAllowed: formData.afternoonAllowed,
+        notes: formData.notes || null,
+        whitelistOnly: formData.whitelistOnly ?? false,
+        slotCustomDates: [],
+        whiteLists: [],
+      });
+      // Save any pending requirements for the new scheduler
+      if (pendingReqs?.length > 0 && created?.id) {
+        for (const req of pendingReqs) {
+          await updateRequirement(created.id, { label: req.label, isDigital: true, isActive: true });
         }
       }
-      await loadSchedulers();
-    } catch (err) {
-      setError(err.message);
+      await loadSchedulers(created?.id);
     }
   };
 
@@ -149,6 +149,7 @@ const AvailabilityManager = () => {
       await loadSchedulers();
     } catch (err) {
       setError(err.message);
+      throw err; // re-throw so the modal (if open) can show the error too
     }
   };
 
@@ -169,7 +170,7 @@ const AvailabilityManager = () => {
             <label className="text-xs font-medium text-secondary-600 dark:text-neutral-300 mb-1.5 block">Active Scheduler</label>
             <select
               value={activeScheduler?.id || ''}
-              onChange={(e) => setActiveScheduler(schedulers.find((s) => s.id === e.target.value) || null)}
+              onChange={(e) => setActiveScheduler(schedulers.find((s) => String(s.id) === e.target.value) || null)}
               className="w-full max-w-xs px-2.5 py-1.5 text-xs bg-neutral-50 dark:bg-neutral-700 border border-neutral-200 dark:border-neutral-600 rounded-md text-secondary-800 dark:text-white focus:outline-none focus:ring-1 focus:ring-primary-500"
             >
               {schedulers.map((s) => (

--- a/mds-staff/src/modules/appointment/components/patient-lookup.jsx
+++ b/mds-staff/src/modules/appointment/components/patient-lookup.jsx
@@ -1,0 +1,258 @@
+import React, { useState, useCallback } from 'react';
+import { resolvePatientByIdentifier, getPatientStatus, getPatientRecords, respondToAppointment, recordAttendance, STATUS } from '../staff-appointment-service';
+import AppointmentDetailModal from './appointment-detail-modal';
+
+const PAGE_SIZE = 10;
+
+const STATUS_COLORS = {
+  Pending:            'bg-warning-100 dark:bg-warning-900/30 text-warning-700 dark:text-warning-400',
+  Scheduled:          'bg-accent-100  dark:bg-accent-900/30  text-accent-700  dark:text-accent-400',
+  InProgress:         'bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-400',
+  Completed:          'bg-success-100 dark:bg-success-900/30 text-success-700 dark:text-success-400',
+  Rejected:           'bg-error-100   dark:bg-error-900/30   text-error-700   dark:text-error-400',
+  CancelledByPatient: 'bg-error-100   dark:bg-error-900/30   text-error-700   dark:text-error-400',
+  CancelledByMedical: 'bg-error-100   dark:bg-error-900/30   text-error-700   dark:text-error-400',
+  NoShow:             'bg-warning-100 dark:bg-warning-900/30 text-warning-700 dark:text-warning-400',
+  Expired:            'bg-neutral-100 dark:bg-neutral-700     text-neutral-500 dark:text-neutral-400',
+};
+
+const PatientLookup = () => {
+  const [inputId, setInputId] = useState('');
+  const [searchedIdentifier, setSearchedIdentifier] = useState(null); // student/employee ID shown in UI
+  const [resolvedUserId, setResolvedUserId] = useState(null);           // internal DB userId
+  const [currentStatus, setCurrentStatus] = useState(null);
+  const [records, setRecords] = useState([]);
+  const [offset, setOffset] = useState(0);
+  const [hasMore, setHasMore] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState('');
+  const [selectedRecord, setSelectedRecord] = useState(null);
+
+  const fetchRecords = useCallback(async (internalId, pageOffset, append = false) => {
+    const data = await getPatientRecords(internalId, pageOffset, PAGE_SIZE);
+    if (append) {
+      setRecords((prev) => [...prev, ...(data || [])]);
+    } else {
+      setRecords(data || []);
+    }
+    setHasMore((data?.length ?? 0) === PAGE_SIZE);
+    return data;
+  }, []);
+
+  const handleSearch = async () => {
+    const raw = inputId.trim();
+    if (!raw) return;
+    const identifierNum = Number(raw);
+    if (!Number.isInteger(identifierNum) || identifierNum <= 0) {
+      setError('Please enter a valid student or employee ID number.');
+      return;
+    }
+    setError('');
+    setLoading(true);
+    setSearchedIdentifier(null);
+    setResolvedUserId(null);
+    setCurrentStatus(null);
+    setRecords([]);
+    setOffset(0);
+    setHasMore(false);
+    try {
+      const internalId = await resolvePatientByIdentifier(identifierNum);
+      if (!internalId) {
+        setError('No patient found with that student / employee ID.');
+        return;
+      }
+      const [status] = await Promise.all([
+        getPatientStatus(internalId),
+        fetchRecords(internalId, 0),
+      ]);
+      setCurrentStatus(status);
+      setSearchedIdentifier(identifierNum);
+      setResolvedUserId(internalId);
+    } catch (err) {
+      setError(err.message || 'Lookup failed. Check the ID and try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const refreshRecords = useCallback(async () => {
+    if (!resolvedUserId) return;
+    const data = await getPatientRecords(resolvedUserId, 0, PAGE_SIZE);
+    setRecords(data || []);
+    setOffset(0);
+    setHasMore((data?.length ?? 0) === PAGE_SIZE);
+  }, [resolvedUserId]);
+
+  const handleModalConfirm = async (patientId) => {
+    await respondToAppointment(patientId, STATUS.SCHEDULED);
+    setSelectedRecord(null);
+    await refreshRecords();
+  };
+
+  const handleModalCancel = async (patientId, reason, cancelStatus) => {
+    await respondToAppointment(patientId, cancelStatus || STATUS.REJECTED, reason);
+    setSelectedRecord(null);
+    await refreshRecords();
+  };
+
+  const handleModalMarkDone = async (id) => {
+    await recordAttendance(id, new Date().toISOString());
+    setSelectedRecord(null);
+    await refreshRecords();
+  };
+
+  const handleModalMarkComplete = async (patientId) => {
+    await respondToAppointment(patientId, STATUS.COMPLETED);
+    setSelectedRecord(null);
+    await refreshRecords();
+  };
+
+  const handleModalMarkNoShow = async (patientId) => {
+    await respondToAppointment(patientId, STATUS.NO_SHOW);
+    setSelectedRecord(null);
+    await refreshRecords();
+  };
+
+  const handleLoadMore = async () => {
+    const nextOffset = offset + PAGE_SIZE;
+    setLoadingMore(true);
+    try {
+      await fetchRecords(resolvedUserId, nextOffset, true);
+      setOffset(nextOffset);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoadingMore(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* Search bar */}
+      <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 p-4">
+        <h3 className="text-sm font-semibold text-secondary-800 dark:text-white mb-3">Patient Appointment Lookup by Student / Employee ID</h3>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={inputId}
+            onChange={(e) => setInputId(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') handleSearch(); }}
+            placeholder="Enter student / employee ID..."
+            className="flex-1 px-3 py-2 text-sm bg-neutral-50 dark:bg-neutral-700 border border-neutral-200 dark:border-neutral-600 rounded-md text-secondary-800 dark:text-white placeholder-secondary-400 dark:placeholder-neutral-500 focus:outline-none focus:ring-1 focus:ring-primary-500 focus:border-primary-500"
+          />
+          <button
+            onClick={handleSearch}
+            disabled={!inputId.trim() || loading}
+            className="px-4 py-2 text-sm font-medium text-white bg-primary-500 hover:bg-primary-600 rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {loading ? 'Searching…' : 'Search'}
+          </button>
+        </div>
+        {error && (
+          <p className="mt-2 text-xs text-error-600 dark:text-error-400">{error}</p>
+        )}
+      </div>
+
+      {/* Results */}
+      {searchedIdentifier && !loading && (
+        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 overflow-hidden">
+          {/* Patient summary header */}
+          <div className="px-4 py-3 border-b border-neutral-200 dark:border-neutral-700 flex items-center justify-between">
+            <div>
+              <p className="text-xs text-secondary-500 dark:text-neutral-400">Student / Employee ID</p>
+              <p className="text-sm font-semibold text-secondary-800 dark:text-white">{searchedIdentifier}</p>
+            </div>
+            <div className="text-right">
+              <p className="text-[10px] text-secondary-500 dark:text-neutral-400 uppercase tracking-wide mb-0.5">Latest Status</p>
+              {currentStatus ? (
+                <span className={`px-2.5 py-1 text-xs font-medium rounded-md ${STATUS_COLORS[currentStatus] || 'bg-neutral-100 text-neutral-600'}`}>
+                  {currentStatus}
+                </span>
+              ) : (
+                <span className="text-xs text-secondary-400 dark:text-neutral-500">No appointments</span>
+              )}
+            </div>
+          </div>
+
+          {/* Records list */}
+          <div className="divide-y divide-neutral-100 dark:divide-neutral-700/60">
+            {records.length === 0 ? (
+              <div className="px-4 py-6 text-center text-sm text-secondary-400 dark:text-neutral-500">
+                No appointment records found for this patient.
+              </div>
+            ) : (
+              records.map((rec, idx) => (
+                <button
+                  key={rec.id}
+                  onClick={() => setSelectedRecord(rec)}
+                  className="w-full px-4 py-3 flex items-start gap-3 text-left hover:bg-neutral-50 dark:hover:bg-neutral-700/40 transition-colors group"
+                >
+                  {/* Index dot */}
+                  <div className="mt-0.5 w-5 h-5 flex-shrink-0 flex items-center justify-center rounded-full bg-neutral-100 dark:bg-neutral-700 group-hover:bg-primary-100 dark:group-hover:bg-primary-900/30 text-[10px] font-bold text-secondary-500 dark:text-neutral-400 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
+                    {idx + 1}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="text-sm font-medium text-secondary-800 dark:text-white">Appointment #{rec.id}</span>
+                      <span className="text-[10px] text-secondary-400 dark:text-neutral-500">{rec.session} session</span>
+                      {rec.created_at && (
+                        <span className="text-[10px] text-secondary-400 dark:text-neutral-500">
+                          {new Date(rec.created_at).toLocaleDateString()}
+                        </span>
+                      )}
+                    </div>
+                    {rec.notes && (
+                      <p className="text-xs text-secondary-500 dark:text-neutral-400 mt-0.5 truncate">{rec.notes}</p>
+                    )}
+                    {rec.requirements?.length > 0 && (
+                      <p className="text-[10px] text-secondary-400 dark:text-neutral-500 mt-0.5">
+                        {rec.requirements.length} requirement{rec.requirements.length !== 1 ? 's' : ''} submitted
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2 flex-shrink-0">
+                    <span className={`px-2 py-0.5 text-[10px] font-medium rounded whitespace-nowrap ${STATUS_COLORS[rec.status] || 'bg-neutral-100 text-neutral-600'}`}>
+                      {rec.status}
+                    </span>
+                    <svg className="w-3.5 h-3.5 text-neutral-300 dark:text-neutral-600 group-hover:text-primary-400 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                    </svg>
+                  </div>
+                </button>
+              ))
+            )}
+          </div>
+
+          {/* Load more */}
+          {hasMore && resolvedUserId && (
+            <div className="px-4 py-3 border-t border-neutral-200 dark:border-neutral-700 text-center">
+              <button
+                onClick={handleLoadMore}
+                disabled={loadingMore}
+                className="px-4 py-1.5 text-xs font-medium text-primary-600 dark:text-primary-400 border border-primary-200 dark:border-primary-800 hover:bg-primary-50 dark:hover:bg-primary-900/20 rounded-md transition-colors disabled:opacity-50"
+              >
+                {loadingMore ? 'Loading…' : 'Load more'}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Detail modal for a clicked record */}
+      {selectedRecord && (
+        <AppointmentDetailModal
+          appointment={selectedRecord}
+          onClose={() => setSelectedRecord(null)}
+          onConfirm={handleModalConfirm}
+          onCancel={handleModalCancel}
+          onMarkDone={handleModalMarkDone}
+          onMarkComplete={handleModalMarkComplete}
+          onMarkNoShow={handleModalMarkNoShow}
+        />
+      )}
+    </div>
+  );
+};
+
+export default PatientLookup;

--- a/mds-staff/src/modules/appointment/components/scheduler-modal.jsx
+++ b/mds-staff/src/modules/appointment/components/scheduler-modal.jsx
@@ -12,12 +12,14 @@ const SchedulerModal = ({ isOpen, onClose, onSave, onDelete, editingScheduler })
   const [newReqLabel, setNewReqLabel] = useState('');
   const [loadingReqs, setLoadingReqs] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [modalError, setModalError] = useState('');
 
   // Reset form when modal opens / scheduler changes
   useEffect(() => {
     if (isOpen) {
       setFormData(getDefaults(editingScheduler));
       setNewReqLabel('');
+      setModalError('');
       if (editingScheduler?.id) {
         loadRequirements(editingScheduler.id);
       } else {
@@ -81,14 +83,17 @@ const SchedulerModal = ({ isOpen, onClose, onSave, onDelete, editingScheduler })
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    if (!formData.label.trim() || formData.schedulePerWeek.length === 0) return;
+    if (!formData.label.trim()) { setModalError('Label is required.'); return; }
+    if (formData.schedulePerWeek.length === 0) { setModalError('Select at least one schedule day.'); return; }
 
     setSaving(true);
+    setModalError('');
     try {
-      // Collect pending local requirements (for new schedulers)
       const pendingReqs = requirements.filter((r) => String(r.id).startsWith('local-'));
       await onSave?.({ ...formData, id: editingScheduler?.id }, pendingReqs);
       onClose();
+    } catch (err) {
+      setModalError(err.message || 'Failed to save scheduler.');
     } finally {
       setSaving(false);
     }
@@ -115,6 +120,14 @@ const SchedulerModal = ({ isOpen, onClose, onSave, onDelete, editingScheduler })
         </div>
 
         <form onSubmit={handleSubmit} className="p-5 space-y-4">
+          {/* Inline error */}
+          {modalError && (
+            <div className="px-3 py-2 bg-error-50 dark:bg-error-900/30 border border-error-200 dark:border-error-800 text-error-700 dark:text-error-400 text-xs rounded-lg flex justify-between items-center">
+              <span>{modalError}</span>
+              <button type="button" onClick={() => setModalError('')} className="ml-2 font-bold">&times;</button>
+            </div>
+          )}
+
           {/* Label */}
           <div>
             <label className="text-xs font-medium text-secondary-600 dark:text-neutral-300 mb-1.5 block">Label</label>
@@ -285,7 +298,15 @@ const SchedulerModal = ({ isOpen, onClose, onSave, onDelete, editingScheduler })
             {isEditing && onDelete && (
               <button
                 type="button"
-                onClick={() => { onDelete(editingScheduler.id); onClose(); }}
+                onClick={async () => {
+                  setModalError('');
+                  try {
+                    await onDelete(editingScheduler.id);
+                    onClose();
+                  } catch (err) {
+                    setModalError(err.message || 'Failed to delete scheduler.');
+                  }
+                }}
                 className="px-4 py-2 text-sm font-medium text-error-600 dark:text-error-400 bg-error-50 dark:bg-error-900/20 hover:bg-error-100 dark:hover:bg-error-900/30 rounded-md transition-colors"
               >
                 Delete

--- a/mds-staff/src/modules/appointment/staff-appointment-service.js
+++ b/mds-staff/src/modules/appointment/staff-appointment-service.js
@@ -90,6 +90,20 @@ export const searchByStatus = async (status, offset = 0, limit = 20) => {
  * @param {string} userId
  * @returns {Promise<string|null>}
  */
+/**
+ * Resolve a patient's internal userId from their student/employee identifier.
+ * @param {number} identifier - Student or employee ID number
+ * @returns {Promise<string|null>}
+ */
+export const resolvePatientByIdentifier = async (identifier) => {
+  const data = await sendGraphQL(`
+    query ResolvePatientByIdentifier($identifier: Int!) {
+      resolvePatientByIdentifier(identifier: $identifier)
+    }
+  `, { identifier: Number(identifier) });
+  return data.resolvePatientByIdentifier;
+};
+
 export const getPatientStatus = async (userId) => {
   const data = await sendGraphQL(`
     query GetUserAppointmentStatus($userId: ID!) {
@@ -112,6 +126,8 @@ export const getPatientRecords = async (userId, offset = 0, limit = 20) => {
       getUserAppointmentRecords(userId: $userId, offset: $offset, limit: $limit) {
         id
         patientId
+        patientIdentifier
+        patientName
         slotEntityId
         status
         session

--- a/mds-staff/src/modules/appointment/staff-appointment.jsx
+++ b/mds-staff/src/modules/appointment/staff-appointment.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import AppointmentQueue from './components/appointment-queue';
 import AvailabilityManager from './components/availability-manager';
 import AppointmentDetailModal from './components/appointment-detail-modal';
+import PatientLookup from './components/patient-lookup';
 import {
   STATUS,
   SESSION,
@@ -133,6 +134,15 @@ const StaffAppointment = () => {
         </svg>
       ),
     },
+    {
+      key: 'lookup',
+      label: 'Patient Lookup',
+      icon: (
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-4.35-4.35M17 11A6 6 0 1 1 5 11a6 6 0 0 1 12 0z" />
+        </svg>
+      ),
+    },
   ];
 
   return (
@@ -180,6 +190,10 @@ const StaffAppointment = () => {
 
       {activeSection === 'availability' && (
         <AvailabilityManager />
+      )}
+
+      {activeSection === 'lookup' && (
+        <PatientLookup />
       )}
 
       {/* Appointment Detail Modal */}


### PR DESCRIPTION
# Appointment — Staff Scheduler fixes, requirement validation, and Patient Lookup

Summary
- Fix various staff-side scheduler bugs (edit/save/delete); ensure FK-safe deletes and inline error handling.
- Fix patient appointment submission validation (DB int vs GraphQL string mismatch for requirement IDs).
- Add Patient Lookup panel and wire appointment history modal in staff UI; history rows open full appointment detail modal.
- Expose resolver to map student/employee identifier → internal userId; ensure `patientIdentifier` and `patientName` are returned in records.

Files changed (high level)
- Backend: routes/appointment/resolvers/wrapper/wrapper.js, medical/medical-resolver.js, schema.graphql
- Frontend (staff): src/modules/appointment/components/{availability-manager.jsx,scheduler-modal.jsx,appointment-detail-modal.jsx,patient-lookup.jsx,staff-appointment.jsx}, staff-appointment-service.js

DB Migration
- Added column: `ALTER TABLE "patientSlot" ADD COLUMN IF NOT EXISTS "rejection_acknowledged" boolean DEFAULT false;`

Testing
- Manual: verified scheduler CRUD (create/edit/delete) flow in staff UI; prevented deletion when active patientSlot exists; inline modal shows errors.
- Patient submit: validated requirement matching works when IDs serialized as strings.
- Patient Lookup: search by student/employee ID resolves to internal userId, loads history, clickable rows open detail modal with full appointment data and actions.

Notes & Rollback
- Rollback: revert schema changes and wrapper resolver; restore previous scheduler delete behavior if needed.
- Permission: `getUserAppointmentStatus` and `getUserAppointmentRecords` guarded by `appointment_allow_view_records`; `resolvePatientByIdentifier` uses same medical permission check.

Reviewer checklist
- Verify DB migration applied on staging/prod before deploying frontend changes.
- Confirm permission checks are acceptable for the new lookup resolver.
- Smoke test appointment actions (Approve/Reject/Record Attendance) from the modal.

