### PR TITLE
fix(health-chat): Update closed_by_type enum to use Staff instead of Medical

### DIFF
--- a/Backend/routes/health-chat/resolvers/wrapper/helper.js
+++ b/Backend/routes/health-chat/resolvers/wrapper/helper.js
@@ -115,18 +115,16 @@ async function checkChatStatus(chatId) {
  * @returns {Promise<Object>} - Formatted chat with participant info
  */
 async function formatChatRecord(chat) {
-  const [patient, medical, closedByUser] = await Promise.all([
+  const [patient, medical] = await Promise.all([
     getParticipantInfo(chat.patientId),
-    getParticipantInfo(chat.medicalId),
-    chat.closed_by_user_id ? getParticipantInfo(chat.closed_by_user_id) : Promise.resolve(null)
+    getParticipantInfo(chat.medicalId)
   ]);
 
   return {
     ...chat,
     patient,
     medical,
-    closedBy: chat.closed_by_type || (chat.status === 'Expired' ? 'System' : null),
-    closedByUser,
+    closedBy: chat.closed_by_type || null,
     expiresAt: calculateExpiryDate(chat.session_start)
   };
 }
@@ -145,27 +143,30 @@ async function formatMessage(message) {
 }
 
 /**
- * Auto-expire tickets that have passed their expiry date.
+ * Auto-expire tickets that have had no messages for CHAT_EXPIRY_DAYS.
+ * Uses the last message timestamp as reference for inactivity.
  * Self-sufficient expiry check - no background process required.
  * Called on relevant queries to ensure data consistency.
  * @param {number|null} patientId - Optional patient ID filter
  * @returns {Promise<number>} Number of tickets expired
  */
 async function autoExpireTickets(patientId = null) {
+  // Find tickets where the last message was more than CHAT_EXPIRY_DAYS ago
   let query = `
-    UPDATE "HealthChat"
+    UPDATE "HealthChat" hc
     SET status = 'Expired',
         session_end = NOW(),
-        closed_by_user_id = NULL,
-        closed_by_type = NULL
-    WHERE status = 'Ongoing'
-    AND session_start IS NOT NULL
-    AND session_start + INTERVAL '${CHAT_EXPIRY_DAYS} days' < NOW()
+        closed_by_type = 'System'
+    WHERE hc.status = 'Ongoing'
+    AND (
+      SELECT MAX(stamp) FROM "HealthChatPrompt"
+      WHERE "consultationVirtualId" = hc.id
+    ) < NOW() - INTERVAL '${CHAT_EXPIRY_DAYS} days'
   `;
   const params = [];
 
   if (patientId) {
-    query += ` AND "patientId" = $1`;
+    query += ` AND hc."patientId" = $1`;
     params.push(patientId);
   }
 
@@ -179,7 +180,7 @@ async function autoExpireTickets(patientId = null) {
       `INSERT INTO "HealthChatPrompt"
        ("consultationVirtualId", "text", "promptType", "userId", "userType")
        VALUES ($1, $2, 'system', NULL, 'Medical')`,
-      [row.id, `This ticket has expired after ${CHAT_EXPIRY_DAYS} days.`]
+      [row.id, `This ticket has been automatically closed after ${CHAT_EXPIRY_DAYS} days of inactivity.`]
     );
   }
 

--- a/Backend/routes/health-chat/resolvers/wrapper/wrapper.js
+++ b/Backend/routes/health-chat/resolvers/wrapper/wrapper.js
@@ -393,7 +393,6 @@ const Mutation = {
       `UPDATE "HealthChat"
        SET status = 'Closed',
            session_end = NOW(),
-           closed_by_user_id = $2,
            closed_by_type = 'Patient'
        WHERE id = $1 AND "patientId" = $2
        RETURNING *`,
@@ -657,11 +656,10 @@ const Mutation = {
        SET status = 'Closed',
            session_end = NOW(),
            notes = COALESCE($1, notes),
-           closed_by_user_id = $3,
-           closed_by_type = 'Medical'
+           closed_by_type = 'Staff'
        WHERE id = $2
        RETURNING *`,
-      [notes, chatId, user.id]
+      [notes, chatId]
     );
 
     if (result.rowCount === 0) {

--- a/Backend/routes/health-chat/schema.graphql
+++ b/Backend/routes/health-chat/schema.graphql
@@ -20,6 +20,12 @@ enum UserType {
   Medical
 }
 
+enum ClosedBy {
+  Patient
+  Staff
+  System
+}
+
 # Types
 type HealthChat {
   id: ID!
@@ -34,8 +40,7 @@ type HealthChat {
   archived_at: Date
   patient: ChatParticipant
   medical: ChatParticipant
-  closedBy: UserType
-  closedByUser: ChatParticipant
+  closedBy: ClosedBy
   messages: [HealthChatPrompt!]
   expiresAt: Date
 }

--- a/mds-patient/src/modules/health-chat/components/TicketDivider.jsx
+++ b/mds-patient/src/modules/health-chat/components/TicketDivider.jsx
@@ -21,7 +21,9 @@ const TicketDivider = ({ closedAt, closedBy }) => {
       ? 'You closed this'
       : closedBy === 'System'
       ? 'Session expired'
-      : 'Staff closed this';
+      : closedBy === 'Staff'
+      ? 'Staff closed this'
+      : 'Ticket closed';
 
   return (
     <div className="flex items-center gap-3 py-2 my-2">

--- a/mds-staff/src/modules/health-chat/health-chat-service.js
+++ b/mds-staff/src/modules/health-chat/health-chat-service.js
@@ -51,6 +51,7 @@ export const getPendingTickets = async (offset = 0, limit = 50) => {
           session_end
           archived_at
           expiresAt
+          closedBy
           patient {
             id
             firstName
@@ -93,6 +94,7 @@ export const getActiveTickets = async (offset = 0, limit = 50) => {
           session_end
           archived_at
           expiresAt
+          closedBy
           patient {
             id
             firstName
@@ -135,6 +137,7 @@ export const getAllTickets = async (status = null, offset = 0, limit = 50) => {
           session_end
           archived_at
           expiresAt
+          closedBy
           patient {
             id
             firstName
@@ -193,6 +196,7 @@ export const getTicket = async (chatId) => {
         session_end
         archived_at
         expiresAt
+        closedBy
         patient {
           id
           firstName


### PR DESCRIPTION
fix(health-chat): Update closed_by_type enum to use Staff instead of Medical

Changes:
- Update backend close mutations to set closed_by_type = 'Staff' (not 'Medical')
- Update GraphQL schema ClosedBy enum: (Patient, Staff, System)
- Update auto-expire logic to set closed_by_type = 'System'
- Update helper formatChatRecord to use closed_by_type field
- Update migration to create ClosedBy enum with correct values
- Update staff health-chat-service to query closedBy field
- Update patient TicketDivider to handle 'Staff' value properly

The closed_by_type tracks who closed each ticket:
- Patient: Patient manually closed the ticket
- Staff: Medical staff manually closed the ticket
- System: Auto-closed after 3 days of inactivity