### PR TITLE
feat (searchpatient, profile patient): Fix Cancelled ticket status bleeding into patient UI

### DIFF
--- a/mds-patient/src/services/emr-service.js
+++ b/mds-patient/src/services/emr-service.js
@@ -1725,46 +1725,24 @@ export const getPatientProfile = async () => {
   });
 
   const log = profileData?.personalLog || {};
-  const activeStatuses = new Set(['InProgress', 'Pending', 'Revision', 'Approved']);
-  const hasActiveProfile = activeStatuses.has(profileData?.personalLogStatus);
 
   let emergencyData = null;
 
-  if (hasActiveProfile) {
-    emergencyData = await sendGraphQLRequest(
-      `query GetEmergencyContact {
-        emergencyContact: getEmergencyContact {
-          firstContact { contactNumber }
-          secondContact { contactNumber }
-        }
-      }`,
-      {}
-    ).catch((error) => {
-      console.warn('[EMR Service] Active emergency contact fetch failed:', error.message);
-      return null;
-    });
-  }
-
-  // Fallback path for users without an active profile: request latest available
-  // emergency contact by user ID when available.
-  if (!emergencyData) {
-    const userId = profileData?.personalRecord?.id || profileData?.personalLog?.id || null;
-
-    if (userId) {
-      emergencyData = await sendGraphQLRequest(
-        `query GetLatestEmergencyContact($userId: ID!, $offset: Int, $limit: Int) {
-          emergencyContacts: getUserEmergencyContact(userId: $userId, offset: $offset, limit: $limit) {
-            firstContact { contactNumber }
-            secondContact { contactNumber }
-          }
-        }`,
-        { userId, offset: 0, limit: 1 }
-      ).catch((error) => {
-        console.warn('[EMR Service] Fallback emergency contact fetch failed:', error.message);
-        return null;
-      });
-    }
-  }
+  // Always fetch the approved emergency contact for profile display.
+  // Using approved:true works regardless of the current update ticket status
+  // (Cancelled, Pending, etc.) and avoids "No active profile found" errors.
+  emergencyData = await sendGraphQLRequest(
+    `query GetEmergencyContact {
+      emergencyContact: getEmergencyContact(approved: true) {
+        firstContact { contactNumber }
+        secondContact { contactNumber }
+      }
+    }`,
+    {}
+  ).catch((error) => {
+    console.warn('[EMR Service] Active emergency contact fetch failed:', error.message);
+    return null;
+  });
 
   const latestEmergency = emergencyData?.emergencyContact
     || (Array.isArray(emergencyData?.emergencyContacts) ? emergencyData.emergencyContacts[0] : null)

--- a/mds-staff/src/modules/search-patient/patient-record-view.jsx
+++ b/mds-staff/src/modules/search-patient/patient-record-view.jsx
@@ -624,7 +624,9 @@ export default function PatientRecordView({ patientId, initialTab: initialTabPro
                 {patient.id} · {patient.program || patient.department || 'N/A'} · {patient.year || 'N/A'}
               </p>
               <div className="mt-1 flex items-center gap-1.5">
-                <span className="px-2 py-0.5 rounded-full text-[11px] font-semibold bg-success-100 dark:bg-success-900/30 text-success-700 dark:text-success-400">{patient.status || 'N/A'}</span>
+                {['InProgress', 'Pending', 'Revision', 'RevisionSubmitted'].includes(patient.status) && (
+                  <span className="px-2 py-0.5 rounded-full text-[11px] font-semibold bg-success-100 dark:bg-success-900/30 text-success-700 dark:text-success-400">{patient.status}</span>
+                )}
                 <span className="px-2 py-0.5 rounded-full text-[11px] font-medium bg-neutral-100 dark:bg-neutral-700 text-secondary-700 dark:text-neutral-300">{patient.type}</span>
                 {isMockPatient && (
                   <span className="px-2 py-0.5 rounded-full text-[11px] font-medium bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-300">Mock Mode</span>


### PR DESCRIPTION
When a patient cancels a record update, the latest patientUpdateLog row holds [status = 'Cancelled'], which was incorrectly surfacing in two places:
Staff patient header — showed a "Cancelled" badge next to the patient's name despite the account being active.

Patient profile modal — threw 404 "No active profile found" when loading the emergency contact, because the resolver rejected the latest ticket row if its status was terminal.

Changes
[patient-record-view.jsx] — Status badge now only renders for active ticket states ([InProgress], [Pending], [Revision], [RevisionSubmitted].
[emr-service.js] — [getPatientProfile()] now always calls [getEmergencyContact(approved: true)], fetching only staff-verified contacts regardless of current ticket state. Returns null cleanly if none exist.