### PR TITLE
feat(analytics): add CSV/Excel/PDF export system with per-chart download

### DIFF
--- a/Backend/package-lock.json
+++ b/Backend/package-lock.json
@@ -19,6 +19,7 @@
         "compression": "^1.8.0",
         "cors": "^2.8.5",
         "dotenv": "^17.2.3",
+        "exceljs": "^4.4.0",
         "expo-server-sdk": "^6.1.0",
         "express": "^5.2.1",
         "express-graphql": "^0.12.0",
@@ -73,6 +74,47 @@
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
       }
+    },
+    "node_modules/@fast-csv/format": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@fast-csv/format/-/format-4.3.5.tgz",
+      "integrity": "sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0"
+      }
+    },
+    "node_modules/@fast-csv/format/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "license": "MIT"
+    },
+    "node_modules/@fast-csv/parse": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@fast-csv/parse/-/parse-4.3.6.tgz",
+      "integrity": "sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.groupby": "^4.6.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.uniq": "^4.5.0"
+      }
+    },
+    "node_modules/@fast-csv/parse/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "license": "MIT"
     },
     "node_modules/@graphql-tools/merge": {
       "version": "9.1.7",
@@ -501,6 +543,81 @@
       "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
       "license": "MIT"
     },
+    "node_modules/archiver": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
+      "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.4",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^2.2.0",
+        "zip-stream": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -555,6 +672,12 @@
         "proxy-from-env": "^2.1.0"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -598,6 +721,28 @@
         "node": ">= 18"
       }
     },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -608,6 +753,12 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -650,6 +801,16 @@
         }
       }
     },
+    "node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/brotli": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
@@ -683,6 +844,15 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -694,6 +864,23 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
+    },
+    "node_modules/buffer-indexof-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+      "engines": {
+        "node": ">=0.2.0"
+      }
     },
     "node_modules/bullmq": {
       "version": "5.71.1",
@@ -810,6 +997,18 @@
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT"
     },
+    "node_modules/chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+      "license": "MIT/X11",
+      "dependencies": {
+        "traverse": ">=0.3.0 <0.4"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/chart.js": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
@@ -924,6 +1123,21 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
+    "node_modules/compress-commons": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
+      "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -967,6 +1181,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
     },
     "node_modules/concat-stream": {
@@ -1024,6 +1244,12 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -1039,6 +1265,31 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
+      "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/cron-parser": {
@@ -1075,6 +1326,12 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
       "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
+      "license": "MIT"
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -1250,6 +1507,51 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/duplexer2/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexer2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -1465,6 +1767,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/exceljs": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/exceljs/-/exceljs-4.4.0.tgz",
+      "integrity": "sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver": "^5.0.0",
+        "dayjs": "^1.8.34",
+        "fast-csv": "^4.3.1",
+        "jszip": "^3.10.1",
+        "readable-stream": "^3.6.0",
+        "saxes": "^5.0.1",
+        "tmp": "^0.2.0",
+        "unzipper": "^0.10.11",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/exceljs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/expand-template": {
@@ -1729,6 +2060,19 @@
         }
       }
     },
+    "node_modules/fast-csv": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-4.3.6.tgz",
+      "integrity": "sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fast-csv/format": "4.3.5",
+        "@fast-csv/parse": "4.3.6"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/fecha": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
@@ -1910,6 +2254,28 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "license": "MIT"
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
+    "node_modules/fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -1971,6 +2337,27 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -1982,6 +2369,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
     },
     "node_modules/graphql": {
       "version": "15.10.2",
@@ -2110,6 +2503,23 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -2462,6 +2872,60 @@
         "npm": ">=6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
@@ -2489,6 +2953,63 @@
       "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
       "license": "MIT"
     },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/linebreak": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
@@ -2508,10 +3029,40 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/listenercount": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+      "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+      "license": "ISC"
+    },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -2532,10 +3083,29 @@
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
       "license": "MIT"
     },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
       "license": "MIT"
     },
     "node_modules/lodash.isnumber": {
@@ -2556,10 +3126,28 @@
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "license": "MIT"
     },
+    "node_modules/lodash.isundefined": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
+      "integrity": "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "license": "MIT"
     },
     "node_modules/logform": {
@@ -2655,6 +3243,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -2662,6 +3262,18 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -2866,6 +3478,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/notepack.io": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-3.0.1.tgz",
@@ -2990,6 +3611,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-to-regexp": {
@@ -3184,6 +3814,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/promise-limit": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/promise-limit/-/promise-limit-2.7.0.tgz",
@@ -3303,6 +3939,36 @@
         "node": ">= 6"
       }
     },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/redis": {
       "version": "5.11.0",
       "resolved": "https://registry.npmjs.org/redis/-/redis-5.11.0.tgz",
@@ -3373,6 +4039,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/router": {
@@ -3459,6 +4138,18 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -3565,6 +4256,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -3952,6 +4649,15 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -3984,6 +4690,15 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/triple-beam": {
       "version": "1.4.1",
@@ -4095,6 +4810,60 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/unzipper": {
+      "version": "0.10.14",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
+      "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "^1.6.17",
+        "binary": "~0.3.0",
+        "bluebird": "~3.4.1",
+        "buffer-indexof-polyfill": "~1.0.0",
+        "duplexer2": "~0.1.4",
+        "fstream": "^1.0.12",
+        "graceful-fs": "^4.2.2",
+        "listenercount": "~1.0.1",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "~1.0.4"
+      }
+    },
+    "node_modules/unzipper/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/unzipper/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/unzipper/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/unzipper/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -4271,6 +5040,12 @@
         }
       }
     },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
+    },
     "node_modules/xss": {
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.15.tgz",
@@ -4294,6 +5069,41 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
+      "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^3.0.4",
+        "compress-commons": "^4.1.2",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/zip-stream/node_modules/archiver-utils": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
+      "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.2.3",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     }
   }

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -21,6 +21,7 @@
     "compression": "^1.8.0",
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",
+    "exceljs": "^4.4.0",
     "expo-server-sdk": "^6.1.0",
     "express": "^5.2.1",
     "express-graphql": "^0.12.0",

--- a/Backend/routes/documents/analytics.js
+++ b/Backend/routes/documents/analytics.js
@@ -4,6 +4,7 @@ const { jwtProtect } = require('../../config/middleware/jwtProtect.js');
 const query = require('../../config/query.js');
 const analytics = require('../../services/analytics-query.js');
 const docGen = require('../../services/doc-generate-module/index.js');
+const analyticsExport = require('../../services/analytics-export.js');
 
 const router = express.Router();
 
@@ -265,6 +266,252 @@ router.get('/report/:reportType', jwtProtect('medical'), async (req, res) => {
     logger.error('Analytics report failed', { error: err.message });
     if (!res.headersSent) {
       res.status(500).json({ error: 'REPORT_FAILED', message: err.message });
+    }
+  }
+});
+
+// ============================================================
+// EXPORT ENDPOINTS (CSV / Excel / PDF)
+// ============================================================
+
+/**
+ * Shared validation middleware for export requests
+ */
+function validateExportParams(req, res) {
+  const { format, branch, startDate, endDate } = req.body;
+
+  if (!format || !['csv', 'excel', 'pdf'].includes(format)) {
+    res.status(400).json({ error: 'INVALID_FORMAT', message: 'format must be csv, excel, or pdf' });
+    return null;
+  }
+  if (!branch) {
+    res.status(400).json({ error: 'BRANCH_REQUIRED' });
+    return null;
+  }
+  const validBranches = ['Manila', 'QuezonCity', 'Both'];
+  if (!validBranches.includes(branch)) {
+    res.status(400).json({ error: 'INVALID_BRANCH' });
+    return null;
+  }
+  if (!startDate || !endDate) {
+    res.status(400).json({ error: 'DATE_RANGE_REQUIRED' });
+    return null;
+  }
+  const start = new Date(startDate);
+  const end = new Date(endDate);
+  if (isNaN(start.getTime()) || isNaN(end.getTime()) || end < start) {
+    res.status(400).json({ error: 'INVALID_DATE_RANGE' });
+    return null;
+  }
+
+  return { format, branch, startDate, endDate };
+}
+
+/**
+ * GET /analytics/export/presets
+ * Get available export presets
+ */
+router.get('/export/presets', jwtProtect('medical'), (req, res) => {
+  res.json({ success: true, presets: analyticsExport.EXPORT_PRESETS });
+});
+
+/**
+ * GET /analytics/export/types
+ * Get available export data types with metadata
+ */
+router.get('/export/types', jwtProtect('medical'), (req, res) => {
+  res.json({ success: true, types: analyticsExport.EXPORT_META });
+});
+
+/**
+ * POST /analytics/export
+ * Export analytics data to the requested format.
+ *
+ * Body:
+ *   - format: 'csv' | 'excel' | 'pdf'
+ *   - branch: 'Manila' | 'QuezonCity' | 'Both'
+ *   - startDate: YYYY-MM-DD
+ *   - endDate: YYYY-MM-DD
+ *   - dataTypes?: string[]     (specific queries to include)
+ *   - preset?: string          (preset name, overrides dataTypes)
+ */
+router.post('/export', jwtProtect('medical'), async (req, res) => {
+  try {
+    const params = validateExportParams(req, res);
+    if (!params) return;
+
+    const { format, branch, startDate, endDate } = params;
+    const { dataTypes: rawDataTypes, preset } = req.body;
+
+    // Resolve which queries to include
+    const dataTypes = analyticsExport.resolveDataTypes(rawDataTypes, preset);
+    if (dataTypes.length === 0) {
+      return res.status(400).json({ error: 'NO_VALID_DATA_TYPES' });
+    }
+
+    // Check user branch access
+    const userBranch = await query.getUserBranch(req.user.id);
+    if (userBranch !== 'Both' && userBranch !== branch && branch !== 'Both') {
+      return res.status(403).json({ error: 'BRANCH_ACCESS_DENIED' });
+    }
+
+    logger.info('Analytics export requested', {
+      format,
+      branch,
+      startDate,
+      endDate,
+      dataTypes: dataTypes.length,
+      preset: preset || null,
+      userId: req.user.id,
+    });
+
+    // Fetch analytics data
+    const data = await analyticsExport.fetchExportData(dataTypes, branch, startDate, endDate);
+
+    if (Object.keys(data).length === 0) {
+      return res.status(404).json({ error: 'NO_DATA', message: 'No data found for the selected queries' });
+    }
+
+    const meta = { branch, startDate, endDate };
+
+    // ── CSV ──────────────────────────────────────────────────
+    if (format === 'csv') {
+      const csv = analyticsExport.generateCSV(data, meta);
+      const filename = analyticsExport.buildFilename(
+        preset || 'analytics', branch, startDate, endDate, 'csv'
+      );
+      res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+      return res.send(csv);
+    }
+
+    // ── Excel ────────────────────────────────────────────────
+    if (format === 'excel') {
+      const workbook = await analyticsExport.generateExcel(data, meta);
+      const filename = analyticsExport.buildFilename(
+        preset || 'analytics', branch, startDate, endDate, 'xlsx'
+      );
+      res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+      return workbook.xlsx.write(res).then(() => res.end());
+    }
+
+    // ── PDF ──────────────────────────────────────────────────
+    if (format === 'pdf') {
+      // Fetch physician info for PDF signature
+      const physicianResult = await require('../../config/db.js').query(
+        `SELECT up.first_name, up.last_name, mp.title
+         FROM "UsersPersonal" up
+         LEFT JOIN "MedicalPersonnel" mp ON up.id = mp.id
+         WHERE up.id = $1`,
+        [req.user.id]
+      );
+      const physician = physicianResult.rows[0] || {};
+
+      meta.physician = {
+        id: req.user.id,
+        firstName: physician.first_name,
+        lastName: physician.last_name,
+        title: physician.title || '',
+      };
+      meta.title = preset
+        ? (analyticsExport.EXPORT_PRESETS[preset]?.label || 'Analytics Report')
+        : 'Analytics Report';
+
+      const { buffer, filename } = await analyticsExport.generatePDF(data, meta);
+      res.setHeader('Content-Type', 'application/pdf');
+      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+      return res.send(buffer);
+    }
+  } catch (err) {
+    logger.error('Analytics export failed', { error: err.message, stack: err.stack });
+    if (!res.headersSent) {
+      res.status(500).json({ error: 'EXPORT_FAILED', message: err.message });
+    }
+  }
+});
+
+/**
+ * POST /analytics/export/single
+ * Export a single metric to PDF (focused report with table + chart).
+ *
+ * Body:
+ *   - dataType: string
+ *   - branch: 'Manila' | 'QuezonCity' | 'Both'
+ *   - startDate: YYYY-MM-DD
+ *   - endDate: YYYY-MM-DD
+ */
+router.post('/export/single', jwtProtect('medical'), async (req, res) => {
+  try {
+    const { dataType, branch, startDate, endDate } = req.body;
+
+    if (!dataType || !analyticsExport.EXPORT_META[dataType]) {
+      return res.status(400).json({ error: 'INVALID_DATA_TYPE' });
+    }
+    if (!branch || !['Manila', 'QuezonCity', 'Both'].includes(branch)) {
+      return res.status(400).json({ error: 'INVALID_BRANCH' });
+    }
+    if (!startDate || !endDate) {
+      return res.status(400).json({ error: 'DATE_RANGE_REQUIRED' });
+    }
+    const start = new Date(startDate);
+    const end = new Date(endDate);
+    if (isNaN(start.getTime()) || isNaN(end.getTime()) || end < start) {
+      return res.status(400).json({ error: 'INVALID_DATE_RANGE' });
+    }
+
+    // Check user branch access
+    const userBranch = await query.getUserBranch(req.user.id);
+    if (userBranch !== 'Both' && userBranch !== branch && branch !== 'Both') {
+      return res.status(403).json({ error: 'BRANCH_ACCESS_DENIED' });
+    }
+
+    logger.info('Single metric export requested', {
+      dataType,
+      branch,
+      startDate,
+      endDate,
+      userId: req.user.id,
+    });
+
+    // Fetch data for single metric
+    const fetchResult = await analyticsExport.fetchExportData([dataType], branch, startDate, endDate);
+    const result = fetchResult[dataType];
+
+    if (!result) {
+      return res.status(404).json({ error: 'NO_DATA' });
+    }
+
+    // Fetch physician info
+    const physicianResult = await require('../../config/db.js').query(
+      `SELECT up.first_name, up.last_name, mp.title
+       FROM "UsersPersonal" up
+       LEFT JOIN "MedicalPersonnel" mp ON up.id = mp.id
+       WHERE up.id = $1`,
+      [req.user.id]
+    );
+    const physician = physicianResult.rows[0] || {};
+
+    const meta = {
+      branch,
+      startDate,
+      endDate,
+      physician: {
+        id: req.user.id,
+        firstName: physician.first_name,
+        lastName: physician.last_name,
+        title: physician.title || '',
+      },
+    };
+
+    const { buffer, filename } = await analyticsExport.generateSingleMetricPDF(dataType, result, meta);
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    return res.send(buffer);
+  } catch (err) {
+    logger.error('Single metric export failed', { error: err.message, stack: err.stack });
+    if (!res.headersSent) {
+      res.status(500).json({ error: 'EXPORT_FAILED', message: err.message });
     }
   }
 });

--- a/Backend/services/analytics-export.js
+++ b/Backend/services/analytics-export.js
@@ -1,0 +1,524 @@
+const ExcelJS = require('exceljs');
+const logger = require('../utils/logger.js');
+const analytics = require('./analytics-query.js');
+const chart = require('./chart.js');
+const pdf = require('./pdfkit.js');
+const docGen = require('./doc-generate-module/index.js');
+
+// ============================================================
+// EXPORT CONFIGURATION
+// ============================================================
+
+/**
+ * Maps dataType → display metadata used across all export formats.
+ * Adding a new query here automatically enables it for CSV/Excel/PDF export.
+ */
+const EXPORT_META = {
+  'consultations-by-type':    { label: 'Consultations by Type',       xAxis: 'Type',          yAxis: 'Count',   chartType: 'pie' },
+  'consultations-by-status':  { label: 'Consultations by Status',     xAxis: 'Status',        yAxis: 'Count',   chartType: 'doughnut' },
+  'consultation-trends':      { label: 'Monthly Consultation Trends', xAxis: 'Month',         yAxis: 'Count',   chartType: 'line' },
+  'top-diagnoses':            { label: 'Top 10 Diagnoses',            xAxis: 'Diagnosis',     yAxis: 'Count',   chartType: 'bar' },
+  'diagnoses-by-type':        { label: 'Diagnoses by Type',           xAxis: 'Type',          yAxis: 'Count',   chartType: 'pie' },
+  'bmi-trends':               { label: 'BMI Trends (Monthly)',        xAxis: 'Month',         yAxis: 'Avg BMI', chartType: 'line' },
+  'blood-pressure-trends':    { label: 'Blood Pressure Trends',       xAxis: 'Month',         yAxis: 'Avg Systolic', chartType: 'line' },
+  'immunization-coverage':    { label: 'Immunization Coverage',       xAxis: 'Vaccine',       yAxis: 'Patients',chartType: 'bar' },
+  'dental-procedures':        { label: 'Top Dental Procedures',       xAxis: 'Procedure',     yAxis: 'Count',   chartType: 'bar' },
+  'lifestyle-risks':          { label: 'Lifestyle Risk Factors',      xAxis: 'Risk Factor',   yAxis: 'Count',   chartType: 'bar' },
+  'allergy-by-type':          { label: 'Allergies by Type',           xAxis: 'Type',          yAxis: 'Count',   chartType: 'pie' },
+  'allergy-by-severity':      { label: 'Allergies by Severity',       xAxis: 'Severity',      yAxis: 'Count',   chartType: 'doughnut' },
+  'appointments-by-category': { label: 'Appointments by Category',    xAxis: 'Category',      yAxis: 'Count',   chartType: 'pie' },
+  'appointments-by-status':   { label: 'Appointments by Status',      xAxis: 'Status',        yAxis: 'Count',   chartType: 'doughnut' },
+  'appointments-by-session':  { label: 'Appointments by Session',     xAxis: 'Session',       yAxis: 'Count',   chartType: 'pie' },
+};
+
+/**
+ * Predefined export presets for quick export options
+ */
+const EXPORT_PRESETS = {
+  'full-report': {
+    label: 'Full Analytics Report',
+    description: 'All 15 analytics metrics combined',
+    dataTypes: Object.keys(EXPORT_META),
+  },
+  'consultations': {
+    label: 'Consultations Report',
+    description: 'Consultation metrics: type, status, trends',
+    dataTypes: ['consultations-by-type', 'consultations-by-status', 'consultation-trends'],
+  },
+  'diagnoses': {
+    label: 'Diagnoses Report',
+    description: 'Diagnosis metrics: top ICD-10, type distribution',
+    dataTypes: ['top-diagnoses', 'diagnoses-by-type'],
+  },
+  'vitals': {
+    label: 'Vital Signs Report',
+    description: 'BMI and blood pressure trend analysis',
+    dataTypes: ['bmi-trends', 'blood-pressure-trends'],
+  },
+  'appointments': {
+    label: 'Appointments Report',
+    description: 'Appointment category, status, and session data',
+    dataTypes: ['appointments-by-category', 'appointments-by-status', 'appointments-by-session'],
+  },
+  'clinical': {
+    label: 'Clinical Data Report',
+    description: 'Immunization coverage and dental procedures',
+    dataTypes: ['immunization-coverage', 'dental-procedures'],
+  },
+  'lifestyle': {
+    label: 'Lifestyle & Allergies Report',
+    description: 'Lifestyle risk factors and allergy data',
+    dataTypes: ['lifestyle-risks', 'allergy-by-type', 'allergy-by-severity'],
+  },
+};
+
+// ============================================================
+// SHARED HELPERS
+// ============================================================
+
+/**
+ * Fetch analytics results for requested data types
+ * @param {string[]} dataTypes
+ * @param {string} branch
+ * @param {string} startDate
+ * @param {string} endDate
+ * @returns {Promise<Object>} Map of dataType → { labels, values, total }
+ */
+async function fetchExportData(dataTypes, branch, startDate, endDate) {
+  const results = await analytics.executeBatchQueries(dataTypes, branch, startDate, endDate);
+  const filtered = {};
+
+  for (const [key, result] of Object.entries(results)) {
+    if (result.success && result.data) {
+      filtered[key] = result.data;
+    }
+  }
+
+  return filtered;
+}
+
+/**
+ * Generate a safe filename string
+ */
+function buildFilename(prefix, branch, startDate, endDate, ext) {
+  const branchSlug = (branch || 'all').replace(/\s+/g, '_').toLowerCase();
+  const dateSlug = `${startDate}_to_${endDate}`;
+  return `${prefix}_${branchSlug}_${dateSlug}.${ext}`;
+}
+
+/**
+ * Resolve data types from either preset name or explicit list
+ */
+function resolveDataTypes(dataTypes, preset) {
+  if (preset && EXPORT_PRESETS[preset]) {
+    return EXPORT_PRESETS[preset].dataTypes;
+  }
+  if (Array.isArray(dataTypes) && dataTypes.length > 0) {
+    return dataTypes.filter(dt => EXPORT_META[dt]);
+  }
+  return Object.keys(EXPORT_META);
+}
+
+/**
+ * Build the display label for a branch
+ */
+function branchLabel(branch) {
+  if (branch === 'Both') return 'All Branches';
+  if (branch === 'QuezonCity') return 'Quezon City';
+  return branch;
+}
+
+// ============================================================
+// CSV EXPORT
+// ============================================================
+
+/**
+ * Generate CSV string from analytics data.
+ * Each data type gets its own section separated by a blank line.
+ *
+ * @param {Object} data - Map of dataType → { labels, values, total }
+ * @param {Object} meta - { branch, startDate, endDate }
+ * @returns {string} CSV content
+ */
+function generateCSV(data, meta) {
+  const lines = [];
+
+  // Header info
+  lines.push(`# Analytics Export`);
+  lines.push(`# Branch: ${branchLabel(meta.branch)}`);
+  lines.push(`# Date Range: ${meta.startDate} to ${meta.endDate}`);
+  lines.push(`# Generated: ${new Date().toISOString()}`);
+  lines.push('');
+
+  // Summary section
+  lines.push('Section,Total');
+  for (const [dataType, result] of Object.entries(data)) {
+    const label = EXPORT_META[dataType]?.label || dataType;
+    lines.push(`"${label}",${result.total || 0}`);
+  }
+  lines.push('');
+
+  // Detailed sections
+  for (const [dataType, result] of Object.entries(data)) {
+    const meta_ = EXPORT_META[dataType];
+    if (!meta_ || !result.labels) continue;
+
+    lines.push(`# ${meta_.label}`);
+    lines.push(`${csvEscape(meta_.xAxis)},${csvEscape(meta_.yAxis)}`);
+
+    for (let i = 0; i < result.labels.length; i++) {
+      lines.push(`${csvEscape(result.labels[i])},${result.values[i] || 0}`);
+    }
+    lines.push(`Total,${result.total || 0}`);
+    lines.push('');
+  }
+
+  return lines.join('\r\n');
+}
+
+function csvEscape(value) {
+  const str = String(value || '');
+  if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+// ============================================================
+// EXCEL EXPORT
+// ============================================================
+
+/**
+ * Generate Excel workbook with summary + per-metric sheets.
+ *
+ * @param {Object} data - Map of dataType → { labels, values, total }
+ * @param {Object} meta - { branch, startDate, endDate }
+ * @returns {Promise<ExcelJS.Workbook>}
+ */
+async function generateExcel(data, meta) {
+  const workbook = new ExcelJS.Workbook();
+  workbook.creator = 'MDSystem Analytics';
+  workbook.created = new Date();
+
+  const headerStyle = {
+    font: { bold: true, color: { argb: 'FFFFFFFF' }, size: 11 },
+    fill: { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FF2F4F4F' } },
+    alignment: { horizontal: 'center', vertical: 'middle' },
+    border: {
+      top: { style: 'thin' }, bottom: { style: 'thin' },
+      left: { style: 'thin' }, right: { style: 'thin' },
+    },
+  };
+
+  const cellBorder = {
+    top: { style: 'thin', color: { argb: 'FFCCCCCC' } },
+    bottom: { style: 'thin', color: { argb: 'FFCCCCCC' } },
+    left: { style: 'thin', color: { argb: 'FFCCCCCC' } },
+    right: { style: 'thin', color: { argb: 'FFCCCCCC' } },
+  };
+
+  // ── Summary Sheet ─────────────────────────────────────────
+  const summarySheet = workbook.addWorksheet('Summary', {
+    properties: { tabColor: { argb: 'FF4CAF50' } },
+  });
+
+  // Title rows
+  summarySheet.mergeCells('A1:C1');
+  const titleCell = summarySheet.getCell('A1');
+  titleCell.value = 'MDSystem Analytics Export';
+  titleCell.font = { bold: true, size: 16, color: { argb: 'FF2F4F4F' } };
+  titleCell.alignment = { horizontal: 'center' };
+
+  summarySheet.mergeCells('A2:C2');
+  summarySheet.getCell('A2').value = `Branch: ${branchLabel(meta.branch)}  |  ${meta.startDate} to ${meta.endDate}`;
+  summarySheet.getCell('A2').font = { size: 10, color: { argb: 'FF666666' } };
+  summarySheet.getCell('A2').alignment = { horizontal: 'center' };
+
+  // Summary table
+  const summaryHeaderRow = summarySheet.getRow(4);
+  summaryHeaderRow.values = ['Metric', 'Total', 'Items'];
+  summaryHeaderRow.eachCell(cell => Object.assign(cell, headerStyle));
+
+  let row = 5;
+  for (const [dataType, result] of Object.entries(data)) {
+    const label = EXPORT_META[dataType]?.label || dataType;
+    const dataRow = summarySheet.getRow(row);
+    dataRow.values = [label, result.total || 0, result.labels?.length || 0];
+    dataRow.eachCell(cell => { cell.border = cellBorder; });
+    row++;
+  }
+
+  summarySheet.columns = [
+    { width: 35 },
+    { width: 15 },
+    { width: 12 },
+  ];
+
+  // ── Per-Metric Sheets ─────────────────────────────────────
+  for (const [dataType, result] of Object.entries(data)) {
+    const meta_ = EXPORT_META[dataType];
+    if (!meta_ || !result.labels) continue;
+
+    // Sheet name limited to 31 chars (Excel limitation)
+    const sheetName = meta_.label.substring(0, 31);
+    const sheet = workbook.addWorksheet(sheetName);
+
+    // Title
+    sheet.mergeCells('A1:B1');
+    const sTitleCell = sheet.getCell('A1');
+    sTitleCell.value = meta_.label;
+    sTitleCell.font = { bold: true, size: 13, color: { argb: 'FF2F4F4F' } };
+
+    sheet.mergeCells('A2:B2');
+    sheet.getCell('A2').value = `Total: ${result.total || 0}`;
+    sheet.getCell('A2').font = { size: 10, color: { argb: 'FF666666' } };
+
+    // Table header
+    const hRow = sheet.getRow(4);
+    hRow.values = [meta_.xAxis, meta_.yAxis];
+    hRow.eachCell(cell => Object.assign(cell, headerStyle));
+
+    // Data rows
+    for (let i = 0; i < result.labels.length; i++) {
+      const r = sheet.getRow(5 + i);
+      r.values = [result.labels[i], result.values[i] || 0];
+      r.eachCell(cell => { cell.border = cellBorder; });
+    }
+
+    // Total row
+    const totalRow = sheet.getRow(5 + result.labels.length);
+    totalRow.values = ['Total', result.total || 0];
+    totalRow.eachCell(cell => {
+      cell.font = { bold: true };
+      cell.border = cellBorder;
+    });
+
+    sheet.columns = [
+      { width: 35 },
+      { width: 18 },
+    ];
+  }
+
+  return workbook;
+}
+
+// ============================================================
+// PDF EXPORT — with tables + embedded charts
+// ============================================================
+
+/**
+ * Generate PDF report buffer.
+ * Each metric gets a data table (top 10 rows) and an embedded chart image.
+ *
+ * @param {Object} data - Map of dataType → { labels, values, total }
+ * @param {Object} meta - { branch, startDate, endDate, title, physician, clinic }
+ * @returns {Promise<{buffer: Buffer, filename: string}>}
+ */
+async function generatePDF(data, meta) {
+  // Build sections for the StaffReportTemplate
+  const sections = [];
+
+  for (const [dataType, result] of Object.entries(data)) {
+    const exportMeta = EXPORT_META[dataType];
+    if (!exportMeta || !result.labels || result.labels.length === 0) continue;
+
+    // Build table data (top 10 for tables with many rows)
+    const maxRows = 10;
+    const tableLabels = result.labels.slice(0, maxRows);
+    const tableValues = result.values.slice(0, maxRows);
+
+    sections.push({
+      title: exportMeta.label,
+      chartType: exportMeta.chartType,
+      labels: tableLabels,
+      values: tableValues,
+      total: result.total || 0,
+      xAxis: exportMeta.xAxis,
+      yAxis: exportMeta.yAxis,
+      summary: `Total: ${result.total || 0}  |  Items shown: ${tableLabels.length}${result.labels.length > maxRows ? ` of ${result.labels.length}` : ''}`,
+    });
+  }
+
+  // Build summary KPIs
+  const summary = {};
+  for (const [dataType, result] of Object.entries(data)) {
+    const label = EXPORT_META[dataType]?.label || dataType;
+    summary[label] = result.total || 0;
+  }
+
+  const docData = {
+    report: {
+      title: meta.title || 'Analytics Report',
+      subtitle: `${meta.startDate} to ${meta.endDate}`,
+      branch: branchLabel(meta.branch),
+      dateRange: { startDate: meta.startDate, endDate: meta.endDate },
+      generatedAt: new Date().toISOString(),
+    },
+    sections,
+    summary,
+    physician: meta.physician || undefined,
+    clinic: meta.clinic || {
+      name: 'TIP Medical-Dental Services',
+      address: meta.branch === 'QuezonCity'
+        ? 'Quezon City Campus, Philippines'
+        : 'Manila Campus, Philippines',
+    },
+  };
+
+  const { template } = await docGen.generateDocument('staff-report', docData);
+  const buffer = await template.toBuffer();
+  const filename = buildFilename('analytics_report', meta.branch, meta.startDate, meta.endDate, 'pdf');
+
+  return { buffer, filename };
+}
+
+// ============================================================
+// SINGLE-METRIC PDF — focused report for one query
+// ============================================================
+
+/**
+ * Generate a focused PDF for a single analytics metric.
+ * Includes a detail table and a chart.
+ *
+ * @param {string} dataType
+ * @param {Object} result - { labels, values, total }
+ * @param {Object} meta - { branch, startDate, endDate, physician }
+ * @returns {Promise<{buffer: Buffer, filename: string}>}
+ */
+async function generateSingleMetricPDF(dataType, result, meta) {
+  const exportMeta = EXPORT_META[dataType];
+  if (!exportMeta) throw new Error(`Unknown export type: ${dataType}`);
+
+  const doc = pdf.createDocument({ size: 'letter' });
+
+  // Header
+  pdf.addHeader(doc, exportMeta.label, `${meta.startDate} to ${meta.endDate}`, {
+    clinicName: 'TIP Medical-Dental Services',
+    address: meta.branch === 'QuezonCity'
+      ? 'Quezon City Campus, Philippines'
+      : 'Manila Campus, Philippines',
+  });
+
+  // Metadata
+  pdf.addSectionHeading(doc, 'Report Information');
+  pdf.addField(doc, 'Branch', branchLabel(meta.branch));
+  pdf.addField(doc, 'Date Range', `${meta.startDate} to ${meta.endDate}`);
+  pdf.addField(doc, 'Total', String(result.total || 0));
+  pdf.addField(doc, 'Generated', new Date().toLocaleString('en-US'));
+  doc.moveDown();
+
+  // Data Table (top 10)
+  pdf.addSectionHeading(doc, 'Data Table');
+  const maxRows = 10;
+  const headers = [exportMeta.xAxis, exportMeta.yAxis, 'Percentage'];
+  const rows = [];
+
+  for (let i = 0; i < Math.min(result.labels.length, maxRows); i++) {
+    const pct = result.total > 0 ? ((result.values[i] / result.total) * 100).toFixed(1) + '%' : '0%';
+    rows.push([result.labels[i], String(result.values[i] || 0), pct]);
+  }
+
+  if (rows.length > 0) {
+    pdf.addTable(doc, headers, rows, {
+      columnWidths: [250, 100, 118],
+    });
+  }
+
+  if (result.labels.length > maxRows) {
+    doc
+      .fontSize(8)
+      .fillColor('#666666')
+      .text(`(Showing top ${maxRows} of ${result.labels.length} items)`, { align: 'center' });
+    doc.moveDown(0.5);
+  }
+
+  // Chart
+  try {
+    const chartLabels = result.labels.slice(0, maxRows);
+    const chartValues = result.values.slice(0, maxRows);
+
+    let chartBuffer;
+    const chartOpts = { width: 450, height: 280, title: exportMeta.label };
+
+    switch (exportMeta.chartType) {
+      case 'pie':
+        chartBuffer = await chart.generatePieChart(chartLabels, chartValues, chartOpts);
+        break;
+      case 'doughnut':
+        chartBuffer = await chart.generateDoughnutChart(chartLabels, chartValues, chartOpts);
+        break;
+      case 'line':
+        chartBuffer = await chart.generateLineChart(chartLabels, [{
+          label: exportMeta.label,
+          data: chartValues,
+          borderColor: '#2196F3',
+          fill: false,
+        }], chartOpts);
+        break;
+      case 'bar':
+      default:
+        chartBuffer = await chart.generateBarChart(chartLabels, [{
+          label: exportMeta.label,
+          data: chartValues,
+          backgroundColor: '#4CAF50',
+        }], chartOpts);
+        break;
+    }
+
+    if (doc.y > 400) doc.addPage();
+
+    pdf.addSectionHeading(doc, 'Chart Visualization');
+    const chartX = (doc.page.width - 450) / 2;
+    pdf.embedImage(doc, chartBuffer, { x: chartX, y: doc.y, width: 450, height: 280 });
+    doc.y += 290;
+  } catch (err) {
+    logger.warn('Chart generation failed for single metric PDF', { dataType, error: err.message });
+    doc.fontSize(8).fillColor('#999').text('[Chart could not be generated]', { align: 'center' });
+  }
+
+  // Footer
+  doc.moveDown();
+  doc.fontSize(8).fillColor('#666666').text(
+    'This report is generated for internal use only.',
+    { align: 'center' }
+  );
+
+  // Physician signature
+  if (meta.physician) {
+    doc.moveDown();
+    const name = `Generated by: ${meta.physician.firstName} ${meta.physician.lastName}`;
+    doc.fontSize(10).font('Helvetica').fillColor('#333333').text(name, { align: 'right' });
+  }
+
+  pdf.addFooter(doc, { text: 'TIP Medical-Dental Services' });
+
+  const buffer = await pdf.toBuffer(doc);
+  const slug = dataType.replace(/[^a-z0-9-]/gi, '_');
+  const filename = buildFilename(slug, meta.branch, meta.startDate, meta.endDate, 'pdf');
+
+  return { buffer, filename };
+}
+
+// ============================================================
+// MODULE EXPORTS
+// ============================================================
+
+module.exports = {
+  // Configuration
+  EXPORT_META,
+  EXPORT_PRESETS,
+
+  // Data fetch
+  fetchExportData,
+
+  // Generators
+  generateCSV,
+  generateExcel,
+  generatePDF,
+  generateSingleMetricPDF,
+
+  // Helpers
+  resolveDataTypes,
+  buildFilename,
+  branchLabel,
+};

--- a/Docs/ANALYTICS_EXPORT.md
+++ b/Docs/ANALYTICS_EXPORT.md
@@ -1,0 +1,159 @@
+# Analytics Export Feature
+
+## Overview
+
+The analytics export feature allows staff users to download analytics data in three formats: **CSV**, **Excel (.xlsx)**, and **PDF**. It supports exporting all metrics, category-based presets, or individual chart metrics.
+
+---
+
+## Architecture
+
+```
+Frontend (mds-staff)                        Backend (Express)
+┌────────────────────────┐                  ┌────────────────────────────────────┐
+│ staff-analytics.jsx    │                  │ routes/documents/analytics.js      │
+│  ├─ Export button       │ ──POST──────▶   │  ├─ POST /analytics/export         │
+│  └─ AnalyticsExportModal│                 │  ├─ POST /analytics/export/single  │
+│                        │                  │  ├─ GET  /analytics/export/presets  │
+│ analytics-chart-card   │                  │  └─ GET  /analytics/export/types   │
+│  └─ Per-chart ↓ button │ ──POST──────▶   │                                    │
+│                        │                  │ services/analytics-export.js       │
+│ analytics-service.js   │                  │  ├─ generateCSV()                  │
+│  ├─ exportAnalytics()  │                  │  ├─ generateExcel()                │
+│  └─ exportSingleMetric()│                 │  ├─ generatePDF()                  │
+└────────────────────────┘                  │  └─ generateSingleMetricPDF()      │
+                                            │                                    │
+                                            │ Leverages:                         │
+                                            │  ├─ analytics-query.js (data)      │
+                                            │  ├─ chart.js (PNG charts)          │
+                                            │  ├─ pdfkit.js (PDF utilities)      │
+                                            │  └─ doc-generate-module (templates)│
+                                            └────────────────────────────────────┘
+```
+
+---
+
+## File Changes
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `Backend/services/analytics-export.js` | Core export service — CSV/Excel/PDF generation |
+| `mds-staff/src/modules/analytics/components/analytics-export-modal.jsx` | Export modal UI component |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `Backend/routes/documents/analytics.js` | Added 4 export endpoints |
+| `mds-staff/src/modules/analytics/analytics-service.js` | Added `exportAnalytics()`, `exportSingleMetric()`, `EXPORT_PRESETS` |
+| `mds-staff/src/modules/analytics/staff-analytics.jsx` | Added Export button + modal integration |
+| `mds-staff/src/modules/analytics/components/analytics-chart-card.jsx` | Added per-card PDF export button |
+| `mds-staff/vite.config.js` | Updated proxy bypass to allow `/analytics/export` and `/analytics/report` |
+
+---
+
+## API Endpoints
+
+### `POST /analytics/export`
+Export multiple metrics in the chosen format.
+
+**Body:**
+```json
+{
+  "format": "csv" | "excel" | "pdf",
+  "branch": "Manila" | "QuezonCity" | "Both",
+  "startDate": "2025-01-01",
+  "endDate": "2025-06-01",
+  "preset": "full-report",        // optional – overrides dataTypes
+  "dataTypes": ["top-diagnoses"]   // optional – specific queries
+}
+```
+**Response:** Binary file download with `Content-Disposition` header.
+
+### `POST /analytics/export/single`
+Export a single metric as a focused PDF with data table + chart.
+
+**Body:**
+```json
+{
+  "dataType": "top-diagnoses",
+  "branch": "Manila",
+  "startDate": "2025-01-01",
+  "endDate": "2025-06-01"
+}
+```
+
+### `GET /analytics/export/presets`
+Returns available export presets with labels and descriptions.
+
+### `GET /analytics/export/types`
+Returns all exportable data types with display metadata (label, axes, chart type).
+
+---
+
+## Export Formats
+
+### CSV
+- Comment-prefixed metadata header (branch, dates, generated timestamp)
+- Summary table: metric name + total
+- Per-metric sections: xAxis/yAxis columns with totals
+- Safe escaping of commas, quotes, and newlines
+
+### Excel (.xlsx)
+- **Summary sheet**: Merged title row, styled header table with metric name/total/items count
+- **Per-metric sheets**: Individual worksheets with formatted data tables
+- Dark green header styling (#2F4F4F), cell borders, auto-widths
+- Uses `exceljs` library
+
+### PDF
+- **Multi-metric report**: Uses existing `StaffReportTemplate` with embedded charts (pie, bar, line, doughnut) and summary KPIs
+- **Single-metric report**: Focused layout with data table (top 10 rows with percentages), embedded chart, physician signature
+- Dynamic filenames: `{metric}_{branch}_{startDate}_to_{endDate}.pdf`
+
+---
+
+## Export Presets
+
+| Preset | Metrics | Description |
+|--------|---------|-------------|
+| `full-report` | All 15 | Complete analytics export |
+| `consultations` | 3 | Type, status, trends |
+| `diagnoses` | 2 | Top ICD-10, type distribution |
+| `vitals` | 2 | BMI, blood pressure trends |
+| `appointments` | 3 | Category, status, session |
+| `clinical` | 2 | Immunization, dental procedures |
+| `lifestyle` | 3 | Risk factors, allergies |
+
+---
+
+## Frontend UI
+
+### Export Modal (`AnalyticsExportModal`)
+- **Format picker**: 3 card buttons (PDF, Excel, CSV) with icons and descriptions
+- **Scope selector**: Dropdown with "Full Report" + all category presets
+- **Summary panel**: Shows branch, date range, and format
+- **Loading state**: Spinner during export
+- **Error handling**: Inline error message
+
+### Per-Chart Export
+Each `AnalyticsChartCard` has a small download icon (↓) in the header. Clicking it triggers a single-metric PDF export for that specific chart.
+
+---
+
+## Dependencies
+
+- **exceljs** (newly installed) — Excel workbook generation
+- **pdfkit** (existing) — PDF document creation
+- **chartjs-node-canvas** (existing) — Server-side chart PNG rendering
+- **doc-generate-module** (existing) — Template-based document generation
+
+---
+
+## Security
+
+- All endpoints require JWT authentication (`jwtProtect('medical')`)
+- Branch access control enforced via `getUserBranch()`
+- Input validation on format, branch, dates, and data types
+- No user-supplied content is used in filenames (slugified from config)

--- a/mds-staff/src/modules/analytics/analytics-service.js
+++ b/mds-staff/src/modules/analytics/analytics-service.js
@@ -143,3 +143,71 @@ export async function fetchMultipleQueries(dataTypes, branch, startDate, endDate
 
   return results;
 }
+
+// ── Export Functions ──────────────────────────────────────────────────────────
+
+/** Export presets mirror – used to populate presets in the UI without an API call */
+export const EXPORT_PRESETS = {
+  'full-report':    { label: 'Full Analytics Report',       description: 'All 15 analytics metrics combined' },
+  'consultations':  { label: 'Consultations Report',        description: 'Consultation metrics: type, status, trends' },
+  'diagnoses':      { label: 'Diagnoses Report',            description: 'Diagnosis metrics: top ICD-10, type distribution' },
+  'vitals':         { label: 'Vital Signs Report',          description: 'BMI and blood pressure trend analysis' },
+  'appointments':   { label: 'Appointments Report',         description: 'Appointment category, status, and session data' },
+  'clinical':       { label: 'Clinical Data Report',        description: 'Immunization coverage and dental procedures' },
+  'lifestyle':      { label: 'Lifestyle & Allergies Report', description: 'Lifestyle risk factors and allergy data' },
+};
+
+/**
+ * Download analytics data as CSV / Excel / PDF.
+ * The response is a Blob (binary file) that gets saved by the browser.
+ *
+ * @param {'csv'|'excel'|'pdf'} format
+ * @param {Object} opts - { branch, startDate, endDate, dataTypes?, preset? }
+ */
+export async function exportAnalytics(format, opts) {
+  const { branch, startDate, endDate, dataTypes, preset } = opts;
+  const response = await axiosRequest.post(
+    '/analytics/export',
+    { format, branch, startDate, endDate, dataTypes, preset },
+    { responseType: 'blob' },
+  );
+
+  triggerDownload(response);
+}
+
+/**
+ * Download a focused single-metric PDF report.
+ * @param {string} dataType
+ * @param {Object} opts - { branch, startDate, endDate }
+ */
+export async function exportSingleMetric(dataType, opts) {
+  const { branch, startDate, endDate } = opts;
+  const response = await axiosRequest.post(
+    '/analytics/export/single',
+    { dataType, branch, startDate, endDate },
+    { responseType: 'blob' },
+  );
+
+  triggerDownload(response);
+}
+
+/**
+ * Trigger browser file download from an Axios blob response.
+ * Extracts filename from Content-Disposition header or falls back.
+ */
+function triggerDownload(response) {
+  const disposition = response.headers?.['content-disposition'] || '';
+  let filename = 'analytics_export';
+
+  const match = disposition.match(/filename="?([^";\n]+)"?/i);
+  if (match) filename = match[1];
+
+  const url = window.URL.createObjectURL(new Blob([response.data]));
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  window.URL.revokeObjectURL(url);
+}

--- a/mds-staff/src/modules/analytics/components/analytics-chart-card.jsx
+++ b/mds-staff/src/modules/analytics/components/analytics-chart-card.jsx
@@ -1,13 +1,26 @@
-import React, { memo } from 'react';
+import React, { memo, useState, useCallback } from 'react';
 import { AnalyticsBarChart, AnalyticsLineChart, AnalyticsPieChart } from './analytics-charts';
-import { CHART_TYPE_MAP } from '../analytics-service';
+import { CHART_TYPE_MAP, exportSingleMetric } from '../analytics-service';
 
 /**
  * Analytics Chart Card
  * Consistent card wrapper for each analytics chart with title, total, and loading states.
  */
-const AnalyticsChartCard = memo(({ dataType, title, data, loading, error, dark }) => {
+const AnalyticsChartCard = memo(({ dataType, title, data, loading, error, dark, branch, startDate, endDate }) => {
   const chartType = CHART_TYPE_MAP[dataType] || 'bar';
+  const [exporting, setExporting] = useState(false);
+
+  const handleExport = useCallback(async () => {
+    if (!branch || !startDate || !endDate) return;
+    setExporting(true);
+    try {
+      await exportSingleMetric(dataType, { branch, startDate, endDate });
+    } catch {
+      // silent — user will see no file downloaded
+    } finally {
+      setExporting(false);
+    }
+  }, [dataType, branch, startDate, endDate]);
 
   // Transform {labels, values} -> [{name, value}]
   const chartData = data?.data
@@ -31,13 +44,32 @@ const AnalyticsChartCard = memo(({ dataType, title, data, loading, error, dark }
             </p>
           )}
         </div>
-        <span className={`px-2 py-0.5 text-[10px] font-medium rounded-full uppercase tracking-wide ${
+        <div className="flex items-center gap-1.5">
+          {/* Per-card export (single metric PDF) */}
+          {!loading && !error && data?.data && (
+            <button
+              onClick={handleExport}
+              disabled={exporting}
+              title="Export as PDF"
+              className="p-1 text-secondary-400 hover:text-primary-500 dark:text-neutral-500 dark:hover:text-primary-400 rounded transition-colors disabled:opacity-50"
+            >
+              {exporting ? (
+                <span className="animate-spin block h-3.5 w-3.5 border-2 border-current border-t-transparent rounded-full" />
+              ) : (
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                </svg>
+              )}
+            </button>
+          )}
+          <span className={`px-2 py-0.5 text-[10px] font-medium rounded-full uppercase tracking-wide ${
           chartType === 'bar' ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400' :
           chartType === 'line' ? 'bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400' :
           'bg-purple-100 dark:bg-purple-900/30 text-purple-600 dark:text-purple-400'
         }`}>
           {chartType === 'doughnut' ? 'pie' : chartType}
         </span>
+        </div>
       </div>
 
       {/* Card Body */}

--- a/mds-staff/src/modules/analytics/components/analytics-export-modal.jsx
+++ b/mds-staff/src/modules/analytics/components/analytics-export-modal.jsx
@@ -1,0 +1,202 @@
+import React, { useState, useCallback, memo } from 'react';
+import { exportAnalytics, EXPORT_PRESETS, QUERY_CATEGORIES } from '../analytics-service';
+
+const FORMAT_OPTIONS = [
+  {
+    value: 'pdf',
+    label: 'PDF Report',
+    description: 'Tables, charts, and summary — presentation-ready',
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
+      </svg>
+    ),
+  },
+  {
+    value: 'excel',
+    label: 'Excel (.xlsx)',
+    description: 'Formatted tables with summary sheet',
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 10h18M3 14h18m-9-4v8m-7 0h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
+      </svg>
+    ),
+  },
+  {
+    value: 'csv',
+    label: 'CSV',
+    description: 'Plain data — import anywhere',
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+      </svg>
+    ),
+  },
+];
+
+const SCOPE_OPTIONS = [
+  { value: 'full-report', label: 'Full Report', description: 'All 15 metrics' },
+  ...Object.entries(QUERY_CATEGORIES).map(([key, cat]) => ({
+    value: key,
+    label: cat.label,
+    description: `${cat.queries.length} metrics`,
+  })),
+];
+
+/**
+ * Analytics Export Modal
+ * Allows the user to pick format, scope (preset), and trigger download.
+ */
+const AnalyticsExportModal = memo(({ open, onClose, branch, startDate, endDate }) => {
+  const [format, setFormat] = useState('pdf');
+  const [scope, setScope] = useState('full-report');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleExport = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await exportAnalytics(format, {
+        branch,
+        startDate,
+        endDate,
+        preset: scope,
+      });
+      onClose();
+    } catch (err) {
+      setError(err?.response?.data?.message || 'Export failed. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }, [format, scope, branch, startDate, endDate, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+
+      {/* Modal */}
+      <div className="relative bg-white dark:bg-neutral-800 rounded-xl shadow-xl w-full max-w-md overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-3.5 border-b border-neutral-200 dark:border-neutral-700">
+          <h3 className="text-sm font-semibold text-secondary-800 dark:text-white">Export Analytics</h3>
+          <button
+            onClick={onClose}
+            className="p-1 text-secondary-400 hover:text-secondary-600 dark:text-neutral-400 dark:hover:text-neutral-200 rounded-md transition-colors"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-5 py-4 space-y-4">
+          {/* Format Selection */}
+          <div>
+            <label className="block text-[11px] font-medium text-secondary-500 dark:text-neutral-400 mb-1.5">Format</label>
+            <div className="grid grid-cols-3 gap-2">
+              {FORMAT_OPTIONS.map((opt) => {
+                const active = format === opt.value;
+                return (
+                  <button
+                    key={opt.value}
+                    onClick={() => setFormat(opt.value)}
+                    className={`flex flex-col items-center gap-1 p-2.5 rounded-lg border text-center transition-colors ${
+                      active
+                        ? 'border-primary-500 bg-primary-50 dark:bg-primary-900/20 text-primary-600 dark:text-primary-400'
+                        : 'border-neutral-200 dark:border-neutral-600 hover:border-neutral-300 dark:hover:border-neutral-500 text-secondary-600 dark:text-neutral-300'
+                    }`}
+                  >
+                    {opt.icon}
+                    <span className="text-xs font-medium">{opt.label}</span>
+                    <span className="text-[10px] text-secondary-400 dark:text-neutral-500 leading-tight">{opt.description}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Scope Selection */}
+          <div>
+            <label className="block text-[11px] font-medium text-secondary-500 dark:text-neutral-400 mb-1.5">Report Scope</label>
+            <select
+              value={scope}
+              onChange={(e) => setScope(e.target.value)}
+              className="w-full px-3 py-2 text-xs rounded-lg border border-neutral-200 dark:border-neutral-600 bg-white dark:bg-neutral-700 text-secondary-800 dark:text-white focus:outline-none focus:ring-1 focus:ring-primary-500"
+            >
+              {SCOPE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label} — {opt.description}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Summary */}
+          <div className="bg-neutral-50 dark:bg-neutral-700/30 rounded-lg px-3 py-2.5 text-[11px] text-secondary-500 dark:text-neutral-400 space-y-0.5">
+            <div className="flex justify-between">
+              <span>Branch</span>
+              <span className="font-medium text-secondary-700 dark:text-neutral-200">
+                {branch === 'Both' ? 'All Branches' : branch === 'QuezonCity' ? 'Quezon City' : branch}
+              </span>
+            </div>
+            <div className="flex justify-between">
+              <span>Period</span>
+              <span className="font-medium text-secondary-700 dark:text-neutral-200">{startDate} to {endDate}</span>
+            </div>
+            <div className="flex justify-between">
+              <span>Format</span>
+              <span className="font-medium text-secondary-700 dark:text-neutral-200">
+                {FORMAT_OPTIONS.find(f => f.value === format)?.label}
+              </span>
+            </div>
+          </div>
+
+          {/* Error */}
+          {error && (
+            <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg px-3 py-2 text-xs text-red-600 dark:text-red-400">
+              {error}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-2 px-5 py-3 border-t border-neutral-200 dark:border-neutral-700">
+          <button
+            onClick={onClose}
+            className="px-3 py-1.5 text-xs font-medium rounded-md text-secondary-600 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleExport}
+            disabled={loading}
+            className="inline-flex items-center gap-1.5 px-4 py-1.5 bg-primary-500 hover:bg-primary-600 disabled:opacity-50 text-white text-xs font-medium rounded-md transition-colors"
+          >
+            {loading ? (
+              <>
+                <span className="animate-spin h-3 w-3 border-2 border-white border-t-transparent rounded-full" />
+                Exporting…
+              </>
+            ) : (
+              <>
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                </svg>
+                Export
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+});
+
+AnalyticsExportModal.displayName = 'AnalyticsExportModal';
+
+export default AnalyticsExportModal;

--- a/mds-staff/src/modules/analytics/staff-analytics.jsx
+++ b/mds-staff/src/modules/analytics/staff-analytics.jsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react'
 import AnalyticsFilterBar from './components/analytics-filter-bar';
 import AnalyticsChartCard from './components/analytics-chart-card';
 import AnalyticsSummaryCards from './components/analytics-summary-cards';
+import AnalyticsExportModal from './components/analytics-export-modal';
 import {
   fetchMultipleQueries,
   fetchAvailableQueries,
@@ -57,6 +58,7 @@ const StaffAnalytics = () => {
   const [results, setResults] = useState(new Map());
   const [loading, setLoading] = useState(false);
   const [initialLoad, setInitialLoad] = useState(true);
+  const [exportOpen, setExportOpen] = useState(false);
   const abortRef = useRef(0);
 
   // Detect dark mode via class on <html>
@@ -105,11 +107,22 @@ const StaffAnalytics = () => {
   return (
     <div className="space-y-3">
       {/* Page Header */}
-      <div>
-        <h1 className="text-lg font-bold text-secondary-800 dark:text-white leading-none m-0">Analytics</h1>
-        <p className="text-[11px] text-secondary-500 dark:text-neutral-400">
-          View clinic performance metrics and health data insights
-        </p>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-lg font-bold text-secondary-800 dark:text-white leading-none m-0">Analytics</h1>
+          <p className="text-[11px] text-secondary-500 dark:text-neutral-400">
+            View clinic performance metrics and health data insights
+          </p>
+        </div>
+        <button
+          onClick={() => setExportOpen(true)}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-secondary-700 hover:bg-secondary-800 dark:bg-neutral-600 dark:hover:bg-neutral-500 text-white text-xs font-medium rounded-md transition-colors"
+        >
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+          </svg>
+          Export
+        </button>
       </div>
 
       {/* Filters */}
@@ -150,6 +163,9 @@ const StaffAnalytics = () => {
               loading={loading && !results.has(queryKey)}
               error={results.get(queryKey)?.error}
               dark={dark}
+              branch={branch}
+              startDate={startDate}
+              endDate={endDate}
             />
           ))}
         </div>
@@ -161,6 +177,15 @@ const StaffAnalytics = () => {
           <p className="text-sm text-secondary-500 dark:text-neutral-400">No analytics queries available for this category.</p>
         </div>
       )}
+
+      {/* Export Modal */}
+      <AnalyticsExportModal
+        open={exportOpen}
+        onClose={() => setExportOpen(false)}
+        branch={branch}
+        startDate={startDate}
+        endDate={endDate}
+      />
     </div>
   );
 };

--- a/mds-staff/vite.config.js
+++ b/mds-staff/vite.config.js
@@ -143,8 +143,8 @@ export default defineConfig(({ mode }) => {
           secure: BACKEND_URL.startsWith('https'),
           bypass: function(req) {
             // Don't proxy GET requests to /analytics (browser navigation) - let React Router handle them
-            // Only proxy API calls (POST, or GET with /analytics/query/ or /analytics/queries path)
-            if (req.method === 'GET' && !req.url.startsWith('/analytics/query') && !req.url.startsWith('/analytics/queries')) {
+            // Only proxy API calls (POST, or GET with API path prefixes)
+            if (req.method === 'GET' && !req.url.startsWith('/analytics/query') && !req.url.startsWith('/analytics/queries') && !req.url.startsWith('/analytics/export') && !req.url.startsWith('/analytics/report')) {
               return '/index.html';
             }
           },


### PR DESCRIPTION
- Add Backend/services/analytics-export.js with generateCSV, generateExcel, generatePDF, and generateSingleMetricPDF (top 10 tables + embedded charts)
- Add 4 export endpoints to analytics route
- Add analytics-export-modal.jsx: format picker (PDF/Excel/CSV) + preset scope selector