### PR TITLE
Health Chat Fix + Appointment Filters + Staff Profile + Admin Bootstrap

### DIFF
--- a/Backend/routes/appointment/resolvers/medical/medical-resolver.js
+++ b/Backend/routes/appointment/resolvers/medical/medical-resolver.js
@@ -55,12 +55,12 @@ const Query = {
     return await Wrapper.Query._listAllAppointmentRequirements(_, { schedulerId, offset, limit, isActive: null }, { user, res });
   },
 
-  searchAppointmentStatuses: async (_, { status, location, offset, limit }, { user, res }) => {
+  searchAppointmentStatuses: async (_, { status, location, date, schedulerId, offset, limit }, { user, res }) => {
     const isPermitted = await permit.isMedicalPermittedBranchBased(user.id, permit.permissions.appointment_allow_view_records, location);
     if (!isPermitted) {
       throwGraphQLError(res).message("Unauthorized").status(401).throw();
     }
-    return await Wrapper.Query._searchAppointmentStatuses(_, { status, location, offset, limit }, { user, res });
+    return await Wrapper.Query._searchAppointmentStatuses(_, { status, location, date, schedulerId, offset, limit }, { user, res });
   },
 
   getAppointmentStatusCounts: async (_, { location }, { user, res }) => {

--- a/Backend/routes/appointment/resolvers/wrapper/wrapper.js
+++ b/Backend/routes/appointment/resolvers/wrapper/wrapper.js
@@ -307,15 +307,14 @@ const Query = {
       WHERE ps.status = $1
       AND ss.location = COALESCE($4::"LocationDesignation", ss.location)
       AND ($5::date IS NULL OR sde."scheduledDate"::date = $5::date)
-      AND ($6::uuid IS NULL OR ss.id = $6::uuid)
+      AND ($6::integer IS NULL OR ss.id = $6::integer)
       ORDER BY sde."scheduledDate" ASC, ps.id DESC
       LIMIT $2 OFFSET $3;
     `;
 
-    const result = await db.query(query, 
-      [status, limit || 10, 
-       offset || 0, location, date || null, schedulerId || null]
-      );
+    const result = await db.query(query,
+      [status, limit || 10,
+       offset || 0, location, date || null, schedulerId ? parseInt(schedulerId, 10) : null]);
     const slots = result.rows;
 
     if (slots.length === 0) return slots;
@@ -344,7 +343,7 @@ const Query = {
       SELECT status, COUNT(*)::int AS count
       FROM "patientSlot"ps
       JOIN "ScheduleDateEntity" sde ON sde.id = ps."slotEntityId"
-      JOIN "SlotScheduler" ss ON ss.id = sde."slotId"
+      JOIN "slotScheduler" ss ON ss.id = sde."slotId"
       WHERE ss.location = COALESCE($1::"LocationDesignation", ss.location)
       GROUP BY status;
     `, [location]);

--- a/Backend/routes/appointment/resolvers/wrapper/wrapper.js
+++ b/Backend/routes/appointment/resolvers/wrapper/wrapper.js
@@ -285,7 +285,7 @@ const Query = {
     return result.rows[0].status;
   },
 
-  _searchAppointmentStatuses: async (_, { status, location, offset, limit }, { user, res }) => {
+  _searchAppointmentStatuses: async (_, { status, location, date, schedulerId, offset, limit }, { user, res }) => {
     if (!user) {
       throwGraphQLError(res).message("Unauthorized").status(401).throw();
     }
@@ -306,13 +306,15 @@ const Query = {
 
       WHERE ps.status = $1
       AND ss.location = COALESCE($4::"LocationDesignation", ss.location)
-      ORDER BY ps.id DESC
+      AND ($5::date IS NULL OR sde."scheduledDate"::date = $5::date)
+      AND ($6::uuid IS NULL OR ss.id = $6::uuid)
+      ORDER BY sde."scheduledDate" ASC, ps.id DESC
       LIMIT $2 OFFSET $3;
     `;
 
     const result = await db.query(query, 
       [status, limit || 10, 
-       offset || 0, location]
+       offset || 0, location, date || null, schedulerId || null]
       );
     const slots = result.rows;
 

--- a/Backend/routes/appointment/schema.graphql
+++ b/Backend/routes/appointment/schema.graphql
@@ -208,7 +208,7 @@ type Query {
   listAllAppointmentRequirements(schedulerId: ID!, offset: Int, limit: Int): [ScheduleRequirement!]
   listMonthAvailability(schedulerId: ID!, startDate: Date!, endDate: Date!): [ScheduleDateEntity!]
 
-  searchAppointmentStatuses(status: SCHEDULING_STATUS!, location: LOCATION_DESIGNATION, offset: Int, limit: Int): [patientSlot!]
+  searchAppointmentStatuses(status: SCHEDULING_STATUS!, location: LOCATION_DESIGNATION, date: Date, schedulerId: ID, offset: Int, limit: Int): [patientSlot!]
   getAppointmentStatusCounts(location: LOCATION_DESIGNATION): [StatusCount!]
   listSchedulerWhitelist(schedulerId: ID!, offset: Int, limit: Int): [WhitelistEntry!]
 }

--- a/Backend/routes/health-chat/resolvers/wrapper/helper.js
+++ b/Backend/routes/health-chat/resolvers/wrapper/helper.js
@@ -348,9 +348,13 @@ async function formatChatRecordsBatch(chats) {
 }
 
 /**
- * Auto-expire tickets that have had no messages for CHAT_EXPIRY_DAYS.
- * Uses the last message timestamp as reference for inactivity.
- * Self-sufficient expiry check - no background process required.
+ * Auto-expire tickets that exceed CHAT_EXPIRY_DAYS.
+ * Two cases are handled:
+ *   1. Ongoing tickets whose session_start + CHAT_EXPIRY_DAYS is in the past
+ *      (matches the expiresAt value shown to patients in the frontend).
+ *   2. Open (pending) tickets that were never approved within CHAT_EXPIRY_DAYS
+ *      (uses archived_at, which is set to current_timestamp on INSERT).
+ * Self-sufficient check — no background process required.
  * Called on relevant queries to ensure data consistency.
  * @param {number|null} patientId - Optional patient ID filter
  * @returns {Promise<number>} Number of tickets expired
@@ -367,41 +371,75 @@ async function autoExpireTickets(patientId = null) {
   }
   if (!patientId) _lastAutoExpireRun = now;
 
-  // Find tickets where the last message was more than CHAT_EXPIRY_DAYS ago
-  // Use parameterized interval to avoid SQL injection
-  const params = [`${CHAT_EXPIRY_DAYS} days`];
-  let query = `
+  const interval = `${CHAT_EXPIRY_DAYS} days`;
+  let expiredCount = 0;
+
+  // ── 1. Expire Ongoing tickets whose session window has elapsed ──────────────
+  // session_start + CHAT_EXPIRY_DAYS < NOW() matches the frontend's expiresAt.
+  // Using extendSession pushes session_start forward, so this stays consistent.
+  const ongoingParams = [interval];
+  let ongoingQuery = `
     UPDATE "HealthChat"
     SET status = 'Expired',
         session_end = NOW(),
         closed_by_type = 'System'
     WHERE status = 'Ongoing'
-    AND (
-      SELECT MAX(stamp) FROM "HealthChatPrompt"
-      WHERE "consultationVirtualId" = "HealthChat".id
-    ) < NOW() - CAST($1 AS INTERVAL)
+    AND session_start IS NOT NULL
+    AND session_start < NOW() - CAST($1 AS INTERVAL)
   `;
 
   if (patientId) {
-    query += ` AND "HealthChat"."patientId" = $2`;
-    params.push(patientId);
+    ongoingQuery += ` AND "patientId" = $2`;
+    ongoingParams.push(patientId);
   }
 
-  query += ` RETURNING id`;
+  ongoingQuery += ` RETURNING id`;
 
-  const result = await db.query(query, params);
+  const ongoingResult = await db.query(ongoingQuery, ongoingParams);
+  expiredCount += ongoingResult.rowCount;
 
-  // Add system message to each expired chat
-  for (const row of result.rows) {
+  for (const row of ongoingResult.rows) {
     await db.query(
       `INSERT INTO "HealthChatPrompt"
        ("consultationVirtualId", "text", "promptType", "userId", "userType")
        VALUES ($1, $2, 'system', NULL, 'Medical')`,
-      [row.id, `This ticket has been automatically closed after ${CHAT_EXPIRY_DAYS} days of inactivity.`]
+      [row.id, `This ticket has been automatically closed by the system after ${CHAT_EXPIRY_DAYS} days of inactivity.`]
     );
   }
 
-  return result.rowCount;
+  // ── 2. Expire Open (pending) tickets with no staff response ─────────────────
+  // archived_at is set to current_timestamp on INSERT, making it the creation time.
+  // If staff never approves within CHAT_EXPIRY_DAYS, expire the request.
+  const openParams = [interval];
+  let openQuery = `
+    UPDATE "HealthChat"
+    SET status = 'Expired',
+        session_end = NOW(),
+        closed_by_type = 'System'
+    WHERE status = 'Open'
+    AND archived_at < NOW() - CAST($1 AS INTERVAL)
+  `;
+
+  if (patientId) {
+    openQuery += ` AND "patientId" = $2`;
+    openParams.push(patientId);
+  }
+
+  openQuery += ` RETURNING id`;
+
+  const openResult = await db.query(openQuery, openParams);
+  expiredCount += openResult.rowCount;
+
+  for (const row of openResult.rows) {
+    await db.query(
+      `INSERT INTO "HealthChatPrompt"
+       ("consultationVirtualId", "text", "promptType", "userId", "userType")
+       VALUES ($1, $2, 'system', NULL, 'Medical')`,
+      [row.id, `This consultation request was automatically closed by the system after ${CHAT_EXPIRY_DAYS} days without a staff response.`]
+    );
+  }
+
+  return expiredCount;
 }
 
 /**

--- a/Backend/routes/health-chat/resolvers/wrapper/helper.js
+++ b/Backend/routes/health-chat/resolvers/wrapper/helper.js
@@ -398,12 +398,15 @@ async function autoExpireTickets(patientId = null) {
   const ongoingResult = await db.query(ongoingQuery, ongoingParams);
   expiredCount += ongoingResult.rowCount;
 
-  for (const row of ongoingResult.rows) {
+  if (ongoingResult.rows.length > 0) {
+    const ongoingMsg = `This ticket has been automatically closed by the system after ${CHAT_EXPIRY_DAYS} days of inactivity.`;
+    const ongoingValues = ongoingResult.rows
+      .map((_, i) => `($${i + 1}, '${ongoingMsg}', 'system', NULL, 'Medical')`)
+      .join(', ');
     await db.query(
-      `INSERT INTO "HealthChatPrompt"
-       ("consultationVirtualId", "text", "promptType", "userId", "userType")
-       VALUES ($1, $2, 'system', NULL, 'Medical')`,
-      [row.id, `This ticket has been automatically closed by the system after ${CHAT_EXPIRY_DAYS} days of inactivity.`]
+      `INSERT INTO "HealthChatPrompt" ("consultationVirtualId", "text", "promptType", "userId", "userType")
+       VALUES ${ongoingValues}`,
+      ongoingResult.rows.map(r => r.id)
     );
   }
 
@@ -430,12 +433,15 @@ async function autoExpireTickets(patientId = null) {
   const openResult = await db.query(openQuery, openParams);
   expiredCount += openResult.rowCount;
 
-  for (const row of openResult.rows) {
+  if (openResult.rows.length > 0) {
+    const openMsg = `This consultation request was automatically closed by the system after ${CHAT_EXPIRY_DAYS} days without a staff response.`;
+    const openValues = openResult.rows
+      .map((_, i) => `($${i + 1}, '${openMsg}', 'system', NULL, 'Medical')`)
+      .join(', ');
     await db.query(
-      `INSERT INTO "HealthChatPrompt"
-       ("consultationVirtualId", "text", "promptType", "userId", "userType")
-       VALUES ($1, $2, 'system', NULL, 'Medical')`,
-      [row.id, `This consultation request was automatically closed by the system after ${CHAT_EXPIRY_DAYS} days without a staff response.`]
+      `INSERT INTO "HealthChatPrompt" ("consultationVirtualId", "text", "promptType", "userId", "userType")
+       VALUES ${openValues}`,
+      openResult.rows.map(r => r.id)
     );
   }
 

--- a/Backend/routes/health-chat/resolvers/wrapper/helper.js
+++ b/Backend/routes/health-chat/resolvers/wrapper/helper.js
@@ -367,8 +367,9 @@ async function autoExpireTickets(patientId = null) {
   }
   if (!patientId) _lastAutoExpireRun = now;
 
-  // Find tickets where the last message was more than CHAT_EXPIRY_DAYS ago
-  // Use parameterized interval to avoid SQL injection
+  // --- 1. Expire Ongoing tickets whose session time has elapsed ---
+  // expiresAt = session_start + CHAT_EXPIRY_DAYS (matches calculateExpiryDate on the frontend).
+  // Also catches tickets with no messages (where MAX(stamp) IS NULL and can never be compared).
   const params = [`${CHAT_EXPIRY_DAYS} days`];
   let query = `
     UPDATE "HealthChat"
@@ -376,10 +377,7 @@ async function autoExpireTickets(patientId = null) {
         session_end = NOW(),
         closed_by_type = 'System'
     WHERE status = 'Ongoing'
-    AND (
-      SELECT MAX(stamp) FROM "HealthChatPrompt"
-      WHERE "consultationVirtualId" = "HealthChat".id
-    ) < NOW() - CAST($1 AS INTERVAL)
+    AND session_start + CAST($1 AS INTERVAL) <= NOW()
   `;
 
   if (patientId) {
@@ -391,17 +389,119 @@ async function autoExpireTickets(patientId = null) {
 
   const result = await db.query(query, params);
 
-  // Add system message to each expired chat
   for (const row of result.rows) {
     await db.query(
       `INSERT INTO "HealthChatPrompt"
        ("consultationVirtualId", "text", "promptType", "userId", "userType")
        VALUES ($1, $2, 'system', NULL, 'Medical')`,
-      [row.id, `This ticket has been automatically closed after ${CHAT_EXPIRY_DAYS} days of inactivity.`]
+      [row.id, `This ticket has been automatically closed after ${CHAT_EXPIRY_DAYS} days.`]
     );
   }
 
-  return result.rowCount;
+  // --- 2. Expire Open tickets for patients whose account has expired ---
+  // Open tickets have no session_start so step 1 never catches them.
+  let openExpiredQuery = `
+    UPDATE "HealthChat" hc
+    SET status = 'Expired',
+        session_end = NOW(),
+        closed_by_type = 'System'
+    FROM "UserCredentials" uc
+    WHERE hc."patientId" = uc.id
+    AND hc.status = 'Open'
+    AND uc.credentials_status = 'Expired'
+  `;
+  const openExpiredParams = [];
+
+  if (patientId) {
+    openExpiredQuery += ` AND hc."patientId" = $1`;
+    openExpiredParams.push(patientId);
+  }
+
+  openExpiredQuery += ` RETURNING hc.id`;
+
+  const openExpiredResult = await db.query(openExpiredQuery, openExpiredParams);
+
+  for (const row of openExpiredResult.rows) {
+    await db.query(
+      `INSERT INTO "HealthChatPrompt"
+       ("consultationVirtualId", "text", "promptType", "userId", "userType")
+       VALUES ($1, $2, 'system', NULL, 'Medical')`,
+      [row.id, 'This ticket has been automatically closed because the patient account has expired.']
+    );
+  }
+
+  // --- 3. Expire stale Open tickets by inactivity (no staff action for CHAT_EXPIRY_DAYS) ---
+  // Uses the last HealthChatPrompt stamp as the activity anchor.
+  // _createTicket inserts a creation system message, so every new Open ticket has at least
+  // one stamp. Tickets with no messages (legacy rows before the anchor fix) are NOT matched
+  // here because MAX(stamp) IS NULL makes the comparison false in SQL — handled by step 4.
+  const staleOpenParams = [`${CHAT_EXPIRY_DAYS} days`];
+  let staleOpenQuery = `
+    UPDATE "HealthChat"
+    SET status = 'Expired',
+        session_end = NOW(),
+        closed_by_type = 'System'
+    WHERE status = 'Open'
+    AND (
+      SELECT MAX(stamp) FROM "HealthChatPrompt"
+      WHERE "consultationVirtualId" = "HealthChat".id
+    ) < NOW() - CAST($1 AS INTERVAL)
+  `;
+
+  if (patientId) {
+    staleOpenQuery += ` AND "HealthChat"."patientId" = $2`;
+    staleOpenParams.push(patientId);
+  }
+
+  staleOpenQuery += ` RETURNING id`;
+
+  const staleOpenResult = await db.query(staleOpenQuery, staleOpenParams);
+
+  for (const row of staleOpenResult.rows) {
+    await db.query(
+      `INSERT INTO "HealthChatPrompt"
+       ("consultationVirtualId", "text", "promptType", "userId", "userType")
+       VALUES ($1, $2, 'system', NULL, 'Medical')`,
+      [row.id, `This ticket has been automatically closed after ${CHAT_EXPIRY_DAYS} days with no staff response.`]
+    );
+  }
+
+  // --- 4. Expire legacy Open tickets with zero messages ---
+  // MAX(stamp) IS NULL means PostgreSQL's < comparison is always false, so step 3 skips them.
+  // Any Open ticket with zero HealthChatPrompt rows is stale by definition — new tickets
+  // always have at least the creation system message from _createTicket.
+  const noMsgParams = [];
+  let noMsgQuery = `
+    UPDATE "HealthChat"
+    SET status = 'Expired',
+        session_end = NOW(),
+        closed_by_type = 'System'
+    WHERE status = 'Open'
+    AND NOT EXISTS (
+      SELECT 1 FROM "HealthChatPrompt"
+      WHERE "consultationVirtualId" = "HealthChat".id
+    )
+  `;
+
+  if (patientId) {
+    noMsgQuery += ` AND "HealthChat"."patientId" = $1`;
+    noMsgParams.push(patientId);
+  }
+
+  noMsgQuery += ` RETURNING id`;
+
+  const noMsgResult = await db.query(noMsgQuery, noMsgParams);
+
+  for (const row of noMsgResult.rows) {
+    await db.query(
+      `INSERT INTO "HealthChatPrompt"
+       ("consultationVirtualId", "text", "promptType", "userId", "userType")
+       VALUES ($1, $2, 'system', NULL, 'Medical')`,
+      [row.id, 'This ticket has been automatically closed (no activity recorded).']
+    );
+  }
+
+  return result.rowCount + openExpiredResult.rowCount + staleOpenResult.rowCount + noMsgResult.rowCount;
 }
 
 /**

--- a/Backend/routes/health-chat/resolvers/wrapper/helper.js
+++ b/Backend/routes/health-chat/resolvers/wrapper/helper.js
@@ -402,12 +402,12 @@ async function autoExpireTickets(patientId = null) {
   if (ongoingResult.rows.length > 0) {
     const ongoingMsg = `This ticket has been automatically closed by the system after ${CHAT_EXPIRY_DAYS} days of inactivity.`;
     const ongoingValues = ongoingResult.rows
-      .map((_, i) => `($${i + 1}, '${ongoingMsg}', 'system', NULL, 'Medical')`)
+      .map((_, i) => `($${i + 2}, $1, 'system', NULL, 'Medical')`)
       .join(', ');
     await db.query(
       `INSERT INTO "HealthChatPrompt" ("consultationVirtualId", "text", "promptType", "userId", "userType")
        VALUES ${ongoingValues}`,
-      ongoingResult.rows.map(r => r.id)
+      [ongoingMsg, ...ongoingResult.rows.map(r => r.id)]
     );
   }
 
@@ -439,12 +439,12 @@ async function autoExpireTickets(patientId = null) {
   if (openExpiredResult.rows.length > 0) {
     const openExpiredMsg = 'This ticket has been automatically closed because the patient account has expired.';
     const openExpiredValues = openExpiredResult.rows
-      .map((_, i) => `($${i + 1}, '${openExpiredMsg}', 'system', NULL, 'Medical')`)
+      .map((_, i) => `($${i + 2}, $1, 'system', NULL, 'Medical')`)
       .join(', ');
     await db.query(
       `INSERT INTO "HealthChatPrompt" ("consultationVirtualId", "text", "promptType", "userId", "userType")
        VALUES ${openExpiredValues}`,
-      openExpiredResult.rows.map(r => r.id)
+      [openExpiredMsg, ...openExpiredResult.rows.map(r => r.id)]
     );
   }
 
@@ -479,12 +479,12 @@ async function autoExpireTickets(patientId = null) {
   if (staleOpenResult.rows.length > 0) {
     const staleMsg = `This consultation request was automatically closed by the system after ${CHAT_EXPIRY_DAYS} days without a staff response.`;
     const staleValues = staleOpenResult.rows
-      .map((_, i) => `($${i + 1}, '${staleMsg}', 'system', NULL, 'Medical')`)
+      .map((_, i) => `($${i + 2}, $1, 'system', NULL, 'Medical')`)
       .join(', ');
     await db.query(
       `INSERT INTO "HealthChatPrompt" ("consultationVirtualId", "text", "promptType", "userId", "userType")
        VALUES ${staleValues}`,
-      staleOpenResult.rows.map(r => r.id)
+      [staleMsg, ...staleOpenResult.rows.map(r => r.id)]
     );
   }
 
@@ -518,12 +518,12 @@ async function autoExpireTickets(patientId = null) {
   if (noMsgResult.rows.length > 0) {
     const noMsgMsg = 'This ticket has been automatically closed (no activity recorded).';
     const noMsgValues = noMsgResult.rows
-      .map((_, i) => `($${i + 1}, '${noMsgMsg}', 'system', NULL, 'Medical')`)
+      .map((_, i) => `($${i + 2}, $1, 'system', NULL, 'Medical')`)
       .join(', ');
     await db.query(
       `INSERT INTO "HealthChatPrompt" ("consultationVirtualId", "text", "promptType", "userId", "userType")
        VALUES ${noMsgValues}`,
-      noMsgResult.rows.map(r => r.id)
+      [noMsgMsg, ...noMsgResult.rows.map(r => r.id)]
     );
   }
 

--- a/Backend/routes/health-chat/resolvers/wrapper/wrapper.js
+++ b/Backend/routes/health-chat/resolvers/wrapper/wrapper.js
@@ -494,6 +494,18 @@ const Mutation = {
       throwGraphQLError(res).message("Failed to create ticket").status(500).throw();
     }
 
+    const chatId = result.rows[0].id;
+
+    // Insert a creation system message so the ticket has an inactivity timestamp anchor.
+    // autoExpireTickets uses MAX(stamp) to detect stale Open tickets; without this
+    // message a pending ticket with no chat activity would never be auto-expired.
+    await db.query(
+      `INSERT INTO "HealthChatPrompt"
+       ("consultationVirtualId", "text", "promptType", "userId", "userType")
+       VALUES ($1, 'Consultation request submitted. Waiting for staff response.', 'system', NULL, 'Medical')`,
+      [chatId]
+    );
+
     const chat = await formatChatRecord(result.rows[0]);
 
     // Notify all medical staff about new ticket
@@ -716,6 +728,7 @@ const Mutation = {
     // Notify all medical staff about ticket status change (so other staff can update their UI)
     emitToRole('medical', 'healthchat:ticket-status-changed', {
       chatId: chat.id,
+      patientId: chat.patientId,
       status: 'Ongoing',
       approvedBy: user.id
     });
@@ -757,6 +770,7 @@ const Mutation = {
        SET status = 'Closed',
            "medicalId" = $1,
            notes = $2,
+           session_end = NOW(),
            closed_by_type = 'Staff'
        WHERE id = $3
        RETURNING *`,
@@ -788,6 +802,7 @@ const Mutation = {
     // Notify all medical staff about ticket status change (so other staff can update their UI)
     emitToRole('medical', 'healthchat:ticket-status-changed', {
       chatId: chat.id,
+      patientId: chat.patientId,
       status: 'Closed',
       rejectedBy: user.id,
       reason: reason || 'Not specified'

--- a/Backend/routes/health-chat/resolvers/wrapper/wrapper.js
+++ b/Backend/routes/health-chat/resolvers/wrapper/wrapper.js
@@ -623,13 +623,13 @@ const Mutation = {
        SET status = 'Closed',
            session_end = NOW(),
            closed_by_type = 'Patient'
-       WHERE id = $1 AND "patientId" = $2
+       WHERE id = $1 AND "patientId" = $2 AND status IN ('Open', 'Ongoing')
        RETURNING *`,
       [chatId, user.id]
     );
 
     if (result.rowCount === 0) {
-      throwGraphQLError(res).message("Failed to close ticket").status(500).throw();
+      throwGraphQLError(res).message("Cannot close this ticket. It may already be closed or expired.").status(400).throw();
     }
 
     // Add system message

--- a/Backend/routes/role-management/resolvers/wrapper/wrapper.js
+++ b/Backend/routes/role-management/resolvers/wrapper/wrapper.js
@@ -1542,33 +1542,50 @@ const Mutation = {
           .throw();
       }
 
+      const allowBootstrapAdmin = process.env.ALLOW_BOOTSTRAP_ADMIN === 'true';
+
+      // Check if new admin has 2FA enabled (bypass in bootstrap mode)
       logger.warn('[ADMIN_TRANSFER_DEBUG] Step 11: getUserConsentStateByEmail(newAdminUser)');
       const newAdminData = await db.getUserConsentStateByEmail(newAdminUser);
       if (!newAdminData?.allow_email_2fa) {
-        await db.setSystemAuditLog({
-          eventType: 'ADMIN_TRANSFER_FAILED',
-          actorId: oldAdminId,
-          actorType: 'Staff',
-          targetId: newAdminUserId,
-          action: 'INITIATE_ADMIN_TRANSFER',
-          details: JSON.stringify({
-            reason: 'Target user 2FA not enabled',
-            timestamp: new Date().toISOString(),
-          }),
-          changedBy: 'Medical',
-        });
+        if (allowBootstrapAdmin) {
+          logger.warn(`[BOOTSTRAP_BYPASS] Target user 2FA check bypassed for newAdminId=${newAdminUserId} (ALLOW_BOOTSTRAP_ADMIN=true)`);
+          await db.setSystemAuditLog({
+            eventType: 'ADMIN_TRANSFER_BOOTSTRAP_BYPASS',
+            actorId: oldAdminId,
+            actorType: 'Staff',
+            targetId: newAdminUserId,
+            action: 'INITIATE_ADMIN_TRANSFER',
+            details: JSON.stringify({
+              reason: 'Bootstrap mode: Target user 2FA check bypassed (ALLOW_BOOTSTRAP_ADMIN=true)',
+              timestamp: new Date().toISOString(),
+            }),
+            changedBy: 'Medical',
+          });
+        } else {
+          await db.setSystemAuditLog({
+            eventType: 'ADMIN_TRANSFER_FAILED',
+            actorId: oldAdminId,
+            actorType: 'Staff',
+            targetId: newAdminUserId,
+            action: 'INITIATE_ADMIN_TRANSFER',
+            details: JSON.stringify({
+              reason: 'Target user 2FA not enabled',
+              timestamp: new Date().toISOString(),
+            }),
+            changedBy: 'Medical',
+          });
 
-        throwGraphQLError(res)
-          .message('Target user must have 2FA enabled before becoming admin.')
-          .status(400)
-          .throw();
+          throwGraphQLError(res)
+            .message('Target user must have 2FA enabled before becoming admin.')
+            .status(400)
+            .throw();
+        }
       }
 
-      // Check if current admin has 2FA enabled
+      // Check if current admin has 2FA enabled (bypass in bootstrap mode)
       logger.warn('[ADMIN_TRANSFER_DEBUG] Step 12: getUserConsentStateByEmail(oldAdminEmail)');
       const oldAdminData = await db.getUserConsentStateByEmail(oldAdminEmail);
-
-      const allowBootstrapAdmin = process.env.ALLOW_BOOTSTRAP_ADMIN === 'true';
 
       if (!oldAdminData?.allow_email_2fa) {
         // Allow bypass if ALLOW_BOOTSTRAP_ADMIN is enabled (for initial admin bootstrap)

--- a/Backend/routes/role-management/schema.graphql
+++ b/Backend/routes/role-management/schema.graphql
@@ -191,6 +191,7 @@ type InitiateAdminTransferResult {
   ok: Boolean!
   message: String!
   verificationRequired: Boolean!
+  bootstrapMode: Boolean!
 }
 
 type ConfirmAdminTransferResult {

--- a/Backend/routes/staff/staff.js
+++ b/Backend/routes/staff/staff.js
@@ -89,8 +89,9 @@ router.get('/me/profile', jwtProtect("medical"), async (req, res) => {
             [req.user.id]
         );
 
+        // A valid JWT guarantees this user exists in UserCredentials
         if (result.rows.length === 0) {
-            return res.status(404).json({ error: 'Profile not found' });
+            return res.status(500).json({ error: 'Unexpected: authenticated user not found in credentials' });
         }
 
         const row = result.rows[0];
@@ -102,7 +103,7 @@ router.get('/me/profile', jwtProtect("medical"), async (req, res) => {
 
         res.json({
             email: row.email || null,
-            name: nameParts.join(' ') || null,
+            name: nameParts.length > 0 ? nameParts.join(' ') : null,
             firstName: row.first_name || null,
             lastName: row.last_name || null,
             role: row.personnel_role || null,

--- a/Backend/routes/staff/staff.js
+++ b/Backend/routes/staff/staff.js
@@ -72,6 +72,49 @@ async function getUserIdViaEmail(email, branch) {
     return result.rows;
 }
 
+// Route: Get current staff's own profile info
+router.get('/me/profile', jwtProtect("medical"), async (req, res) => {
+    try {
+        const result = await db.query(
+            `SELECT
+               uc.email,
+               up.first_name, up.middle_name, up.last_name,
+               mp.role AS personnel_role,
+               mp.designation AS branch,
+               mp.is_active
+             FROM "UserCredentials" uc
+             LEFT JOIN "UsersPersonal" up ON up.id = uc.id
+             LEFT JOIN "MedicalPersonnel" mp ON mp.id = uc.id
+             WHERE uc.id = $1`,
+            [req.user.id]
+        );
+
+        if (result.rows.length === 0) {
+            return res.status(404).json({ error: 'Profile not found' });
+        }
+
+        const row = result.rows[0];
+        const nameParts = [
+            row.first_name,
+            row.middle_name ? `${row.middle_name[0]}.` : null,
+            row.last_name,
+        ].filter(Boolean);
+
+        res.json({
+            email: row.email || null,
+            name: nameParts.join(' ') || null,
+            firstName: row.first_name || null,
+            lastName: row.last_name || null,
+            role: row.personnel_role || null,
+            branch: row.branch || null,
+            isActive: row.is_active ?? true,
+        });
+    } catch (error) {
+        logger.error('Error fetching own profile:', error);
+        res.status(500).json({ error: 'Internal server error' });
+    }
+});
+
 // Route: Get current user's module permissions
 router.get('/me/permissions', jwtProtect("medical"), async (req, res) => {
     try {

--- a/mds-patient/src/modules/health-chat/components/TicketDivider.jsx
+++ b/mds-patient/src/modules/health-chat/components/TicketDivider.jsx
@@ -4,7 +4,7 @@ import React from 'react';
  * TicketDivider — patient side
  * A soft, warm visual break between closed and new conversations
  */
-const TicketDivider = ({ closedAt, closedBy }) => {
+const TicketDivider = ({ closedAt, closedBy, ticketStatus }) => {
   const formatDate = (dateStr) => {
     if (!dateStr) return 'Unknown date';
     return new Date(dateStr).toLocaleDateString('en-US', {
@@ -16,21 +16,24 @@ const TicketDivider = ({ closedAt, closedBy }) => {
     });
   };
 
-  const closedByText =
-    closedBy === 'Patient'
-      ? 'Ticket Closed by: Patient'
-      : closedBy === 'System'
-      ? 'Ticket Closed by: System'
-      : closedBy === 'Staff'
-      ? 'Ticket Closed by: Staff'
-      : 'Ticket Closed';
+  const getClosedByText = () => {
+    if (closedBy === 'System' || ticketStatus === 'Expired') {
+      // Distinguish between a session that timed out vs a request that was never answered
+      // If closedAt exists and there was no session_start (Open → Expired), it's an unanswered request.
+      // We use a single generic label since both cases are "System" from the DB.
+      return 'Auto-closed by System · 3 days inactivity';
+    }
+    if (closedBy === 'Patient') return 'Ticket Closed by: Patient';
+    if (closedBy === 'Staff')   return 'Ticket Closed by: Staff';
+    return 'Ticket Closed';
+  };
 
   return (
     <div className="flex items-center gap-3 py-3 my-3">
       <div className="flex-1 h-px bg-neutral-200 dark:bg-neutral-700" />
       <div className="flex items-center gap-1.5 px-4 py-1.5 rounded-full text-xs font-medium whitespace-nowrap bg-neutral-100 dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 text-neutral-400 dark:text-neutral-500">
         <span className="w-1.5 h-1.5 rounded-full flex-shrink-0 bg-neutral-300 dark:bg-neutral-600" />
-        {closedByText} · {formatDate(closedAt)}
+        {getClosedByText()} · {formatDate(closedAt)}
       </div>
       <div className="flex-1 h-px bg-neutral-200 dark:bg-neutral-700" />
     </div>

--- a/mds-patient/src/modules/health-chat/health-chat.jsx
+++ b/mds-patient/src/modules/health-chat/health-chat.jsx
@@ -153,8 +153,16 @@ const HealthChat = () => {
     const pollInterval = setInterval(async () => {
       try {
         const updatedTicket = await getCurrentActiveTicket();
-        if (updatedTicket && updatedTicket.status !== 'Open') {
-          // Ticket status changed! Update local state
+        if (!updatedTicket) {
+          // Previously-open ticket is no longer active — it was auto-expired or closed.
+          // Load the most recent ticket so the UI shows the closed/expired state and
+          // the patient can create a new conversation instead of being stuck.
+          console.log('[HealthChat] Polling: active ticket gone, loading most recent.');
+          const mostRecent = await getMostRecentTicket();
+          setTicket(mostRecent);
+          if (mostRecent?.id) await loadMessages(mostRecent.id);
+        } else if (updatedTicket.status !== 'Open') {
+          // Ticket status changed (e.g. Approved → Ongoing)
           console.log('[HealthChat] Polling detected status change:', updatedTicket.status);
           setTicket(updatedTicket);
           if (updatedTicket.id) {
@@ -517,6 +525,7 @@ const HealthChat = () => {
                 <TicketDivider
                   closedAt={ticket.session_end || ticket.archived_at || ticket.expiresAt}
                   closedBy={ticket.closedBy || (ticket.status === 'Expired' ? 'System' : 'Unknown')}
+                  ticketStatus={ticket.status}
                 />
               </div>
             )}

--- a/mds-staff/src/components/layout/StaffSidebar.jsx
+++ b/mds-staff/src/components/layout/StaffSidebar.jsx
@@ -4,6 +4,7 @@ import logo from '@core/assets/MDSystem.png';
 import { useHealthChatBadge } from '../../modules/health-chat/hooks/use-health-chat-badge';
 import { usePermissions } from '../../context/permissions-context';
 import { useSettings } from '../../context/settings-context';
+import { useStaffProfile } from '../../hooks/use-staff-profile';
 
 /**
  * Staff Sidebar Navigation Component
@@ -15,6 +16,7 @@ const StaffSidebar = ({ isOpen, isExpanded, onClose, onToggleExpand }) => {
   const { hasPermission, isAdmin, isLoading } = usePermissions();
   const { settings } = useSettings();
   const showBadges = settings.showBadges;
+  const { profile } = useStaffProfile();
 
   const allNavItems = [
     { path: '/', icon: 'dashboard', label: 'Dashboard', exact: true },
@@ -183,15 +185,15 @@ const StaffSidebar = ({ isOpen, isExpanded, onClose, onToggleExpand }) => {
             isExpanded ? '' : 'justify-center'
           }`}>
             <div className="w-8 h-8 bg-primary-500 rounded-full flex items-center justify-center text-white text-xs font-medium flex-shrink-0">
-              DR
+              {profile?.firstName?.[0] ?? profile?.email?.[0]?.toUpperCase() ?? 'S'}
             </div>
             {isExpanded && (
               <div className="flex-1 min-w-0">
-                <p className="text-xs font-medium text-secondary-800 dark:text-white truncate">
-                  Dr. Staff
+                <p className="text-xs font-medium text-secondary-800 dark:text-white truncate" title={profile?.email ?? ''}>
+                  {profile?.email ?? '—'}
                 </p>
                 <p className="text-xs text-secondary-500 dark:text-neutral-400 truncate">
-                  Medical Doctor
+                  {profile?.role ?? '—'}
                 </p>
               </div>
             )}

--- a/mds-staff/src/components/layout/StaffTopBar.jsx
+++ b/mds-staff/src/components/layout/StaffTopBar.jsx
@@ -4,7 +4,7 @@ import { logout } from '../../packages-core-adapter';
 import { useStaffNotifications } from '../../modules/notification/notification-context';
 import { useSettings } from '../../context/settings-context';
 import { usePatientTabs } from '../../context/patient-tabs-context';
-import { useStaffProfile } from '../../hooks/use-staff-profile';
+import { useStaffProfile, clearStaffProfileCache } from '../../hooks/use-staff-profile';
 
 function formatRelativeTime(iso) {
   const diff = Date.now() - new Date(iso).getTime();
@@ -578,9 +578,11 @@ const StaffTopBar = ({ onMenuClick, isSidebarOpen }) => {
                   onClick={async () => {
                     try {
                       clearTabs();
+                      clearStaffProfileCache();
                       await logout(true);
                     } catch {
                       clearTabs();
+                      clearStaffProfileCache();
                       window.location.href = '/auth';
                     }
                   }}

--- a/mds-staff/src/components/layout/StaffTopBar.jsx
+++ b/mds-staff/src/components/layout/StaffTopBar.jsx
@@ -4,6 +4,7 @@ import { logout } from '../../packages-core-adapter';
 import { useStaffNotifications } from '../../modules/notification/notification-context';
 import { useSettings } from '../../context/settings-context';
 import { usePatientTabs } from '../../context/patient-tabs-context';
+import { useStaffProfile } from '../../hooks/use-staff-profile';
 
 function formatRelativeTime(iso) {
   const diff = Date.now() - new Date(iso).getTime();
@@ -28,6 +29,7 @@ const StaffTopBar = ({ onMenuClick, isSidebarOpen }) => {
 
   const { notifications, unreadCount, markAsRead, markAllAsRead, inventoryAlerts, markInventoryAlertsAsSeen, clearNotificationsByType } = useStaffNotifications();
   const { settings, updateSettings } = useSettings();
+  const { profile } = useStaffProfile();
   const { clearTabs } = usePatientTabs();
   const { themeMode } = settings;
   const displayUnreadCount = settings.showBadges ? unreadCount : 0;
@@ -515,7 +517,7 @@ const StaffTopBar = ({ onMenuClick, isSidebarOpen }) => {
             className="flex items-center gap-2 p-1 rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-700"
           >
             <div className="w-7 h-7 bg-primary-500 rounded-full flex items-center justify-center text-white text-xs font-medium">
-              DR
+              {profile?.firstName?.[0] ?? profile?.email?.[0]?.toUpperCase() ?? 'S'}
             </div>
             <svg className="w-4 h-4 text-secondary-500 dark:text-neutral-400 hidden sm:block" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
@@ -524,10 +526,32 @@ const StaffTopBar = ({ onMenuClick, isSidebarOpen }) => {
 
           {/* User Dropdown */}
           {showUserMenu && (
-            <div className="absolute right-0 mt-2 w-48 bg-white dark:bg-neutral-800 rounded-lg shadow-lg border border-neutral-200 dark:border-neutral-700 py-1 z-50">
-              <div className="px-3 py-2 border-b border-neutral-200 dark:border-neutral-700">
-                <p className="text-sm font-medium text-secondary-800 dark:text-white">Dr. Staff</p>
-                <p className="text-xs text-secondary-500 dark:text-neutral-400">Medical Doctor</p>
+            <div className="absolute right-0 mt-2 w-64 bg-white dark:bg-neutral-800 rounded-lg shadow-lg border border-neutral-200 dark:border-neutral-700 py-1 z-50">
+              <div className="px-3 py-3 border-b border-neutral-200 dark:border-neutral-700 space-y-0.5">
+                {profile?.name && (
+                  <p className="text-sm font-semibold text-secondary-800 dark:text-white truncate" title={profile.name}>
+                    {profile.name}
+                  </p>
+                )}
+                {profile?.email && (
+                  <p className="text-xs text-secondary-500 dark:text-neutral-400 truncate" title={profile.email}>
+                    {profile.email}
+                  </p>
+                )}
+                {(profile?.role || profile?.branch) && (
+                  <div className="flex items-center gap-1.5 flex-wrap pt-0.5">
+                    {profile?.role && (
+                      <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-400">
+                        {profile.role}
+                      </span>
+                    )}
+                    {profile?.branch && (
+                      <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-neutral-100 dark:bg-neutral-700 text-secondary-600 dark:text-neutral-300">
+                        {profile.branch}
+                      </span>
+                    )}
+                  </div>
+                )}
               </div>
               <button className="w-full px-3 py-2 text-left text-sm text-secondary-600 dark:text-neutral-300 hover:bg-neutral-50 dark:hover:bg-neutral-700">
                 Profile

--- a/mds-staff/src/hooks/use-staff-profile.js
+++ b/mds-staff/src/hooks/use-staff-profile.js
@@ -1,9 +1,23 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { axiosRequest } from '../packages-core-adapter';
 
+// Module-level cache shared across all hook instances
 let cachedProfile = null;
 let cacheTimestamp = 0;
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+// In-flight promise: deduplicates concurrent requests from multiple components
+let inFlight = null;
+
+/**
+ * Clear the cached profile — call this on logout so the next
+ * login session always fetches fresh data.
+ */
+export function clearStaffProfileCache() {
+  cachedProfile = null;
+  cacheTimestamp = 0;
+  inFlight = null;
+}
 
 /**
  * Hook to fetch and cache the current staff member's profile.
@@ -13,29 +27,52 @@ const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
  *   { email, name, firstName, lastName, role, branch, isActive }
  */
 export function useStaffProfile() {
-  const [profile, setProfile] = useState(cachedProfile);
-  const [isLoading, setIsLoading] = useState(!cachedProfile);
+  const isCached = cachedProfile && Date.now() - cacheTimestamp < CACHE_TTL_MS;
+  const [profile, setProfile] = useState(isCached ? cachedProfile : null);
+  const [isLoading, setIsLoading] = useState(!isCached);
   const [error, setError] = useState(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
 
   const fetchProfile = useCallback(async (force = false) => {
     const now = Date.now();
     if (!force && cachedProfile && now - cacheTimestamp < CACHE_TTL_MS) {
-      setProfile(cachedProfile);
-      setIsLoading(false);
+      if (mountedRef.current) {
+        setProfile(cachedProfile);
+        setIsLoading(false);
+      }
       return;
     }
 
+    // Reuse the same in-flight promise if one is already running
+    if (!inFlight) {
+      inFlight = axiosRequest.get('/staff/me/profile').then((res) => {
+        cachedProfile = res.data;
+        cacheTimestamp = Date.now();
+        return cachedProfile;
+      }).finally(() => {
+        inFlight = null;
+      });
+    }
+
+    if (mountedRef.current) setIsLoading(true);
+
     try {
-      setIsLoading(true);
-      setError(null);
-      const response = await axiosRequest.get('/staff/me/profile');
-      cachedProfile = response.data;
-      cacheTimestamp = Date.now();
-      setProfile(cachedProfile);
+      const data = await inFlight;
+      if (mountedRef.current) {
+        setProfile(data);
+        setError(null);
+      }
     } catch (err) {
-      setError(err.message || 'Failed to load profile');
+      if (mountedRef.current) {
+        setError(err.message || 'Failed to load profile');
+      }
     } finally {
-      setIsLoading(false);
+      if (mountedRef.current) setIsLoading(false);
     }
   }, []);
 

--- a/mds-staff/src/hooks/use-staff-profile.js
+++ b/mds-staff/src/hooks/use-staff-profile.js
@@ -1,0 +1,47 @@
+import { useState, useEffect, useCallback } from 'react';
+import { axiosRequest } from '../packages-core-adapter';
+
+let cachedProfile = null;
+let cacheTimestamp = 0;
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Hook to fetch and cache the current staff member's profile.
+ * Returns { profile, isLoading, error, refetch }.
+ *
+ * profile shape:
+ *   { email, name, firstName, lastName, role, branch, isActive }
+ */
+export function useStaffProfile() {
+  const [profile, setProfile] = useState(cachedProfile);
+  const [isLoading, setIsLoading] = useState(!cachedProfile);
+  const [error, setError] = useState(null);
+
+  const fetchProfile = useCallback(async (force = false) => {
+    const now = Date.now();
+    if (!force && cachedProfile && now - cacheTimestamp < CACHE_TTL_MS) {
+      setProfile(cachedProfile);
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      setIsLoading(true);
+      setError(null);
+      const response = await axiosRequest.get('/staff/me/profile');
+      cachedProfile = response.data;
+      cacheTimestamp = Date.now();
+      setProfile(cachedProfile);
+    } catch (err) {
+      setError(err.message || 'Failed to load profile');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchProfile();
+  }, [fetchProfile]);
+
+  return { profile, isLoading, error, refetch: () => fetchProfile(true) };
+}

--- a/mds-staff/src/modules/appointment/components/appointment-queue.jsx
+++ b/mds-staff/src/modules/appointment/components/appointment-queue.jsx
@@ -220,14 +220,12 @@ const AppointmentQueue = forwardRef(({ onViewDetails }, ref) => {
               </span>
             ) : (
               tabCounts[tab.key] !== undefined && (
-                <span
-                  title={filterDate || filterSchedulerId ? 'Global count — filters are active' : undefined}
-                  className={`ml-0.5 px-1.5 py-0.5 text-[10px] rounded-full font-semibold transition-opacity ${filterDate || filterSchedulerId ? 'opacity-40' : ''} ${
-                    activeTab === tab.key
-                      ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-400'
-                      : 'bg-neutral-100 dark:bg-neutral-700 text-secondary-500 dark:text-neutral-400'
-                  }`}>
-                  {formatCount(tabCounts[tab.key])}{filterDate || filterSchedulerId ? '*' : ''}
+                <span className={`ml-0.5 px-1.5 py-0.5 text-[10px] rounded-full font-semibold ${
+                  activeTab === tab.key
+                    ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-400'
+                    : 'bg-neutral-100 dark:bg-neutral-700 text-secondary-500 dark:text-neutral-400'
+                }`}>
+                  {formatCount(tabCounts[tab.key])}
                 </span>
               )
             )}

--- a/mds-staff/src/modules/appointment/components/appointment-queue.jsx
+++ b/mds-staff/src/modules/appointment/components/appointment-queue.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo, forwardRef, useImperativeHandle } from 'react';
-import { searchByStatus, getStatusCounts } from '../staff-appointment-service';
+import { searchByStatus, getStatusCounts, listAllSchedulers } from '../staff-appointment-service';
 
 /* ── constants ─────────────────────────────────────── */
 
@@ -51,6 +51,11 @@ const AppointmentQueue = forwardRef(({ onViewDetails }, ref) => {
   const [tabCounts,    setTabCounts]    = useState({});
   const [loadingCounts, setLoadingCounts] = useState(true);
 
+  // Filter state
+  const [filterDate,        setFilterDate]        = useState('');
+  const [filterSchedulerId, setFilterSchedulerId] = useState('');
+  const [schedulers,        setSchedulers]        = useState([]);
+
   // Pagination state
   const [offset,      setOffset]      = useState(0);
   const [hasMore,     setHasMore]     = useState(false);
@@ -79,11 +84,11 @@ const AppointmentQueue = forwardRef(({ onViewDetails }, ref) => {
   }, []);
 
   /* Fetch appointments (first page or fresh load) */
-  const fetchAppointments = useCallback(async (status) => {
+  const fetchAppointments = useCallback(async (status, date, schedulerId) => {
     setLoading(true);
     setOffset(0);
     try {
-      const data = await searchByStatus(status, 0, PAGE_SIZE);
+      const data = await searchByStatus(status, 0, PAGE_SIZE, { date: date || null, schedulerId: schedulerId || null });
       setAppointments(data || []);
       setHasMore((data?.length ?? 0) === PAGE_SIZE);
     } catch (err) {
@@ -118,10 +123,15 @@ const AppointmentQueue = forwardRef(({ onViewDetails }, ref) => {
       refreshCounts();
     },
     refresh: () => {
-      fetchAppointments(activeTab);
+      fetchAppointments(activeTab, filterDate, filterSchedulerId);
       refreshCounts();
     },
-  }), [activeTab, fetchAppointments, refreshCounts]);
+  }), [activeTab, fetchAppointments, refreshCounts, filterDate, filterSchedulerId]);
+
+  /* Load schedulers once on mount for the filter dropdown */
+  useEffect(() => {
+    listAllSchedulers().then(setSchedulers).catch(() => {});
+  }, []);
 
   /* Load status counts once on mount */
   useEffect(() => {
@@ -136,17 +146,17 @@ const AppointmentQueue = forwardRef(({ onViewDetails }, ref) => {
     loadCounts();
   }, [refreshCounts]);
 
-  /* Fetch appointments whenever the active tab changes */
+  /* Fetch appointments whenever the active tab or active filters change */
   useEffect(() => {
-    fetchAppointments(activeTab);
-  }, [activeTab, fetchAppointments]);
+    fetchAppointments(activeTab, filterDate, filterSchedulerId);
+  }, [activeTab, filterDate, filterSchedulerId, fetchAppointments]);
 
   /* Load more (pagination) */
   const handleLoadMore = useCallback(async () => {
     const nextOffset = offset + PAGE_SIZE;
     setLoadingMore(true);
     try {
-      const data = await searchByStatus(activeTab, nextOffset, PAGE_SIZE);
+      const data = await searchByStatus(activeTab, nextOffset, PAGE_SIZE, { date: filterDate || null, schedulerId: filterSchedulerId || null });
       setAppointments((prev) => [...prev, ...(data || [])]);
       setHasMore((data?.length ?? 0) === PAGE_SIZE);
       setOffset(nextOffset);
@@ -155,7 +165,7 @@ const AppointmentQueue = forwardRef(({ onViewDetails }, ref) => {
     } finally {
       setLoadingMore(false);
     }
-  }, [activeTab, offset]);
+  }, [activeTab, offset, filterDate, filterSchedulerId]);
 
   /* Client-side search filter on patientIdentifier / name / email */
   const rows = useMemo(() => {
@@ -174,7 +184,7 @@ const AppointmentQueue = forwardRef(({ onViewDetails }, ref) => {
   const handleTabChange = (key) => {
     if (key === activeTab) {
       // Same tab clicked — force refresh
-      fetchAppointments(key);
+      fetchAppointments(key, filterDate, filterSchedulerId);
       refreshCounts();
     } else {
       setActiveTab(key);
@@ -238,9 +248,60 @@ const AppointmentQueue = forwardRef(({ onViewDetails }, ref) => {
             className="w-full pl-8 pr-3 py-1.5 text-xs bg-neutral-50 dark:bg-neutral-700 border border-neutral-200 dark:border-neutral-600 rounded-md text-secondary-800 dark:text-white placeholder-secondary-400 dark:placeholder-neutral-500 focus:outline-none focus:ring-1 focus:ring-primary-500 focus:border-primary-500"
           />
         </div>
+
+        {/* Date filter */}
+        <div className="relative">
+          <svg className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-secondary-400 dark:text-neutral-500 pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+          </svg>
+          <input
+            type="date"
+            value={filterDate}
+            onChange={(e) => setFilterDate(e.target.value)}
+            className="pl-8 pr-3 py-1.5 text-xs bg-neutral-50 dark:bg-neutral-700 border border-neutral-200 dark:border-neutral-600 rounded-md text-secondary-800 dark:text-white focus:outline-none focus:ring-1 focus:ring-primary-500 focus:border-primary-500"
+          />
+          {filterDate && (
+            <button
+              onClick={() => setFilterDate('')}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-secondary-400 dark:text-neutral-500 hover:text-secondary-600 dark:hover:text-neutral-300"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          )}
+        </div>
+
+        {/* Scheduler filter */}
+        <div className="relative">
+          <svg className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-secondary-400 dark:text-neutral-500 pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+          </svg>
+          <select
+            value={filterSchedulerId}
+            onChange={(e) => setFilterSchedulerId(e.target.value)}
+            className="pl-8 pr-6 py-1.5 text-xs bg-neutral-50 dark:bg-neutral-700 border border-neutral-200 dark:border-neutral-600 rounded-md text-secondary-800 dark:text-white focus:outline-none focus:ring-1 focus:ring-primary-500 focus:border-primary-500 appearance-none max-w-[180px]"
+          >
+            <option value="">All Schedulers</option>
+            {schedulers.map((s) => (
+              <option key={s.id} value={s.id}>{s.label}</option>
+            ))}
+          </select>
+        </div>
+
+        {/* Clear filters button — only when any filter active */}
+        {(filterDate || filterSchedulerId) && (
+          <button
+            onClick={() => { setFilterDate(''); setFilterSchedulerId(''); }}
+            className="px-2.5 py-1.5 text-xs bg-error-50 dark:bg-error-900/20 border border-error-200 dark:border-error-800 rounded-md text-error-600 dark:text-error-400 hover:bg-error-100 dark:hover:bg-error-900/40 transition-colors whitespace-nowrap"
+          >
+            Clear Filters
+          </button>
+        )}
+
         {/* Result count + refresh */}
         <button
-          onClick={() => { fetchAppointments(activeTab); refreshCounts(); }}
+          onClick={() => { fetchAppointments(activeTab, filterDate, filterSchedulerId); refreshCounts(); }}
           className="px-2.5 py-1.5 text-xs bg-neutral-50 dark:bg-neutral-700 border border-neutral-200 dark:border-neutral-600 rounded-md text-secondary-600 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-600 transition-colors"
         >
           Refresh

--- a/mds-staff/src/modules/appointment/components/appointment-queue.jsx
+++ b/mds-staff/src/modules/appointment/components/appointment-queue.jsx
@@ -220,12 +220,14 @@ const AppointmentQueue = forwardRef(({ onViewDetails }, ref) => {
               </span>
             ) : (
               tabCounts[tab.key] !== undefined && (
-                <span className={`ml-0.5 px-1.5 py-0.5 text-[10px] rounded-full font-semibold ${
-                  activeTab === tab.key
-                    ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-400'
-                    : 'bg-neutral-100 dark:bg-neutral-700 text-secondary-500 dark:text-neutral-400'
-                }`}>
-                  {formatCount(tabCounts[tab.key])}
+                <span
+                  title={filterDate || filterSchedulerId ? 'Global count — filters are active' : undefined}
+                  className={`ml-0.5 px-1.5 py-0.5 text-[10px] rounded-full font-semibold transition-opacity ${filterDate || filterSchedulerId ? 'opacity-40' : ''} ${
+                    activeTab === tab.key
+                      ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-400'
+                      : 'bg-neutral-100 dark:bg-neutral-700 text-secondary-500 dark:text-neutral-400'
+                  }`}>
+                  {formatCount(tabCounts[tab.key])}{filterDate || filterSchedulerId ? '*' : ''}
                 </span>
               )
             )}
@@ -250,20 +252,23 @@ const AppointmentQueue = forwardRef(({ onViewDetails }, ref) => {
         </div>
 
         {/* Date filter */}
-        <div className="relative">
-          <svg className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-secondary-400 dark:text-neutral-500 pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-          </svg>
-          <input
-            type="date"
-            value={filterDate}
-            onChange={(e) => setFilterDate(e.target.value)}
-            className="pl-8 pr-3 py-1.5 text-xs bg-neutral-50 dark:bg-neutral-700 border border-neutral-200 dark:border-neutral-600 rounded-md text-secondary-800 dark:text-white focus:outline-none focus:ring-1 focus:ring-primary-500 focus:border-primary-500"
-          />
+        <div className="flex items-center gap-1">
+          <div className="relative">
+            <svg className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-secondary-400 dark:text-neutral-500 pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </svg>
+            <input
+              type="date"
+              value={filterDate}
+              onChange={(e) => setFilterDate(e.target.value)}
+              className="pl-8 pr-3 py-1.5 text-xs bg-neutral-50 dark:bg-neutral-700 border border-neutral-200 dark:border-neutral-600 rounded-md text-secondary-800 dark:text-white focus:outline-none focus:ring-1 focus:ring-primary-500 focus:border-primary-500"
+            />
+          </div>
           {filterDate && (
             <button
               onClick={() => setFilterDate('')}
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-secondary-400 dark:text-neutral-500 hover:text-secondary-600 dark:hover:text-neutral-300"
+              title="Clear date filter"
+              className="p-1 rounded text-secondary-400 dark:text-neutral-500 hover:text-secondary-600 dark:hover:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors"
             >
               <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -382,7 +387,11 @@ const AppointmentQueue = forwardRef(({ onViewDetails }, ref) => {
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
                     </svg>
                     <p className="text-sm font-medium text-secondary-500 dark:text-neutral-400">No appointments found</p>
-                    <p className="text-xs text-secondary-400 dark:text-neutral-500 mt-0.5">No {activeTab} appointments at the moment</p>
+                    <p className="text-xs text-secondary-400 dark:text-neutral-500 mt-0.5">
+                      {filterDate || filterSchedulerId
+                        ? 'Try adjusting or clearing the active filters'
+                        : `No ${activeTab} appointments at the moment`}
+                    </p>
                   </td>
                 </tr>
               )}

--- a/mds-staff/src/modules/appointment/staff-appointment-service.js
+++ b/mds-staff/src/modules/appointment/staff-appointment-service.js
@@ -73,10 +73,10 @@ const sendGraphQL = async (query, variables = {}) => {
  * @param {number} [limit=20]
  * @returns {Promise<Array>} patientSlot[]
  */
-export const searchByStatus = async (status, offset = 0, limit = 20) => {
+export const searchByStatus = async (status, offset = 0, limit = 20, { date, schedulerId } = {}) => {
   const data = await sendGraphQL(`
-    query SearchAppointmentStatuses($status: SCHEDULING_STATUS!, $offset: Int, $limit: Int) {
-      searchAppointmentStatuses(status: $status, offset: $offset, limit: $limit) {
+    query SearchAppointmentStatuses($status: SCHEDULING_STATUS!, $offset: Int, $limit: Int, $date: Date, $schedulerId: ID) {
+      searchAppointmentStatuses(status: $status, offset: $offset, limit: $limit, date: $date, schedulerId: $schedulerId) {
         id
         patientId
         patientIdentifier
@@ -100,7 +100,7 @@ export const searchByStatus = async (status, offset = 0, limit = 20) => {
         }
       }
     }
-  `, { status, offset, limit });
+  `, { status, offset, limit, date: date || null, schedulerId: schedulerId || null });
   return data.searchAppointmentStatuses;
 };
 

--- a/mds-staff/src/modules/role-management/components/admin-transfer.jsx
+++ b/mds-staff/src/modules/role-management/components/admin-transfer.jsx
@@ -49,12 +49,15 @@ const AdminTransfer = () => {
     setIsInitiating(true);
     try {
       const result = await initiateAdminTransfer(selectedUserId, password);
-      if (result.ok && result.verificationRequired) {
-        setPassword('');
-        setStep('verify');
-      } else if (result.ok && result.bootstrapMode) {
+      if (result.ok && result.bootstrapMode) {
         setPassword('');
         setStep('bootstrap');
+      } else if (result.ok && result.verificationRequired) {
+        setPassword('');
+        setStep('verify');
+      } else if (result.ok) {
+        // Unexpected response shape — surface the server message
+        setInitiateError(result.message || 'Unexpected response from server.');
       }
     } catch (err) {
       setInitiateError(err.message || 'Failed to initiate transfer.');
@@ -324,7 +327,7 @@ const AdminTransfer = () => {
         </form>
       )}
 
-      {/* ── Step 3: Success ── */}
+      {/* ── Step 4: Success ── */}
       {step === 'success' && (
         <div className="text-center py-6">
           <div className="w-12 h-12 mx-auto mb-3 rounded-full bg-success-100 dark:bg-success-900/30 flex items-center justify-center">
@@ -337,7 +340,7 @@ const AdminTransfer = () => {
             {transferResult?.message || 'Admin privileges have been transferred successfully.'}
           </p>
           <p className="text-[11px] text-secondary-400 dark:text-neutral-500">
-            You no longer have admin access. The page will redirect shortly.
+            You no longer have admin access. Please refresh the page.
           </p>
         </div>
       )}

--- a/mds-staff/src/modules/role-management/components/admin-transfer.jsx
+++ b/mds-staff/src/modules/role-management/components/admin-transfer.jsx
@@ -3,10 +3,11 @@ import { fetchStaffAccounts, initiateAdminTransfer, confirmAdminTransfer } from 
 
 /**
  * Admin Transfer Component
- * Two-step flow: initiate (select target + password) → confirm (verification token from email)
+ * Normal flow:    initiate (select target + password) → verify (email OTP) → success
+ * Bootstrap flow: initiate (select target + password) → bootstrap (direct confirm) → success
  */
 const AdminTransfer = () => {
-  const [step, setStep] = useState('initiate'); // 'initiate' | 'verify' | 'success'
+  const [step, setStep] = useState('initiate'); // 'initiate' | 'verify' | 'bootstrap' | 'success'
   const [staffList, setStaffList] = useState([]);
   const [isLoadingStaff, setIsLoadingStaff] = useState(true);
 
@@ -51,11 +52,30 @@ const AdminTransfer = () => {
       if (result.ok && result.verificationRequired) {
         setPassword('');
         setStep('verify');
+      } else if (result.ok && result.bootstrapMode) {
+        setPassword('');
+        setStep('bootstrap');
       }
     } catch (err) {
       setInitiateError(err.message || 'Failed to initiate transfer.');
     } finally {
       setIsInitiating(false);
+    }
+  };
+
+  const handleBootstrapConfirm = async () => {
+    setConfirmError(null);
+    setIsConfirming(true);
+    try {
+      const result = await confirmAdminTransfer('BOOTSTRAP_ADMIN_TRANSFER');
+      if (result.ok) {
+        setTransferResult(result);
+        setStep('success');
+      }
+    } catch (err) {
+      setConfirmError(err.message || 'Failed to confirm transfer.');
+    } finally {
+      setIsConfirming(false);
     }
   };
 
@@ -101,7 +121,7 @@ const AdminTransfer = () => {
             <p className="text-xs font-semibold text-error-700 dark:text-error-400">Irreversible Action</p>
             <p className="text-[11px] text-error-600 dark:text-error-300 mt-0.5">
               Transferring admin privileges cannot be undone. You will lose admin access permanently.
-              A verification code will be sent to your email.
+              A verification code will be sent to your email unless the system is in bootstrap mode.
             </p>
           </div>
         </div>
@@ -182,7 +202,70 @@ const AdminTransfer = () => {
         </form>
       )}
 
-      {/* ── Step 2: Verify ── */}
+      {/* ── Step 2 (Bootstrap): Direct confirm ── */}
+      {step === 'bootstrap' && (
+        <div className="space-y-4">
+          {/* Bootstrap mode banner */}
+          <div className="px-3.5 py-3 bg-warning-50 dark:bg-warning-900/20 border border-warning-200 dark:border-warning-800 rounded-lg">
+            <div className="flex items-start gap-2">
+              <svg className="w-4 h-4 text-warning-500 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <div>
+                <p className="text-xs font-semibold text-warning-700 dark:text-warning-400">Bootstrap Mode Active</p>
+                <p className="text-[11px] text-warning-600 dark:text-warning-300 mt-0.5">
+                  The system is running in bootstrap mode. 2FA verification and email confirmation are bypassed.
+                  The transfer will complete immediately upon confirmation.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Target staff preview */}
+          {selectedStaff && (
+            <div className="px-3 py-2.5 bg-neutral-50 dark:bg-neutral-800/50 border border-neutral-200 dark:border-neutral-700 rounded-lg">
+              <p className="text-[10px] font-medium text-secondary-400 dark:text-neutral-500 uppercase tracking-wide mb-1.5">Transferring to</p>
+              <div className="flex items-center gap-2">
+                <div className="w-7 h-7 rounded-full bg-gradient-to-br from-primary-400 to-primary-600 flex items-center justify-center text-[9px] font-bold text-white flex-shrink-0">
+                  {selectedStaff.name.split(' ').map((n) => n[0]).join('').substring(0, 2)}
+                </div>
+                <div>
+                  <p className="text-xs font-medium text-secondary-800 dark:text-white">{selectedStaff.name}</p>
+                  <p className="text-[10px] text-secondary-400 dark:text-neutral-500">{selectedStaff.email} · {selectedStaff.branch}</p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {confirmError && (
+            <div className="px-3 py-2 bg-error-50 dark:bg-error-900/20 border border-error-200 dark:border-error-800 rounded-lg">
+              <p className="text-xs text-error-600 dark:text-error-400">{confirmError}</p>
+            </div>
+          )}
+
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={handleReset}
+              disabled={isConfirming}
+              className="px-4 py-2 text-sm font-medium text-secondary-600 dark:text-neutral-400 hover:text-secondary-800 dark:hover:text-white transition-colors disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleBootstrapConfirm}
+              disabled={isConfirming}
+              className="flex-1 px-4 py-2 text-sm font-medium bg-warning-500 text-white rounded-lg hover:bg-warning-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center justify-center gap-2"
+            >
+              {isConfirming && <span className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />}
+              {isConfirming ? 'Confirming...' : 'Confirm Transfer'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* ── Step 3: Verify (normal flow) ── */}
       {step === 'verify' && (
         <form onSubmit={handleConfirm} className="space-y-4">
           <div className="px-3.5 py-3 bg-primary-50 dark:bg-primary-900/20 border border-primary-200 dark:border-primary-800 rounded-lg">

--- a/mds-staff/src/modules/role-management/staff-service.js
+++ b/mds-staff/src/modules/role-management/staff-service.js
@@ -170,6 +170,7 @@ const GQL_INITIATE_ADMIN_TRANSFER = `
       ok
       message
       verificationRequired
+      bootstrapMode
     }
   }
 `;


### PR DESCRIPTION
# Pull Request: frontend-jay → development

**Branch:** `frontend-jay`  
**Target:** `development`  
**Date:** April 4, 2026  
**Authors:** @K1taru, @Soley999  
**Labels:** `bug fixes`, `enhancement`

---

## Summary

This PR covers four distinct areas of work:

1. **Health Chat — expired ticket logic rewrite** (backend + patient frontend)
2. **Appointment Queue — date & scheduler filters** (backend + staff frontend)
3. **Staff Dashboard — live user profile display** (backend + staff frontend)
4. **Role Management — bootstrap mode for admin transfer** (backend + staff frontend)

---

## 1. Health Chat

### Problem

Expired health chat tickets were blocking patients from creating new ones. "You already have an active ticket" appeared even after a ticket had expired, because:

- `autoExpireTickets` compared `MAX(stamp) < NOW() - 3 days`, but the frontend computed expiry as `session_start + 3 days`, causing a mismatch.
- `Open` (pending, never approved) tickets were never expired at all, so they permanently blocked new tickets.
- `_closeMyTicket` had no status guard, meaning a patient could overwrite an already-`Expired` status with `Closed`, corrupting the audit trail.
- The patient polling loop did not handle the case where `getCurrentActiveTicket()` returns `null` (ticket auto-expired mid-session), leaving the UI stuck.
- `TicketDivider` showed generic "Ticket Closed by: System" text for expired tickets instead of a more descriptive label.

### Changes

#### Backend — `helper.js`

`autoExpireTickets(patientId)` rewritten from a single-step query into four distinct steps, all using batch `INSERT ... VALUES` (not per-row loops):

| Step | Covers | SQL anchor |
|------|--------|-----------|
| 1 | `Ongoing` tickets | `session_start + INTERVAL <= NOW()` (matches frontend `expiresAt`) |
| 2 | `Open` tickets where the patient account is `Expired` in `UserCredentials` | Account-level credential status |
| 3 | Stale `Open` tickets with at least one message | `MAX(stamp) < NOW() - INTERVAL` (creation system message from `_createTicket` is the guaranteed anchor) |
| 4 | Legacy `Open` tickets with zero messages | `NOT EXISTS` in `HealthChatPrompt` |

All four `INSERT INTO "HealthChatPrompt"` calls use proper parameterized queries (`$1` for message text, `$2+` for IDs) rather than string interpolation.

A 30-second cooldown is applied for global (non-patient-scoped) calls to avoid redundant sweeps.

#### Backend — `wrapper.js`

- **`_createTicket`**: After inserting the new chat row, inserts a creation system message (`'Consultation request submitted. Waiting for staff response.'`). This gives step 3 of `autoExpireTickets` a timestamp anchor for every new `Open` ticket.
- **`_closeMyTicket`**: Added `AND status IN ('Open', 'Ongoing')` to the `WHERE` clause. If the ticket is already `Closed` or `Expired`, the query returns `rowCount = 0` and a `400` error is returned instead of silently corrupting the status.
- **`_rejectTicket`** (merged from `backend-soley`): Added `session_end = NOW()` to the `UPDATE` — this was missing before, leaving `session_end` null on staff-rejected tickets.
- **`_approveTicket` / `_rejectTicket` socket events** (merged from `backend-soley`): Added `patientId: chat.patientId` to the `healthchat:ticket-status-changed` payload so the patient-side socket handler can identify the correct ticket.

#### Patient Frontend — `health-chat.jsx`

Polling useEffect (active when `status = 'Open'`) now handles the `null` return from `getCurrentActiveTicket()`:

```js
if (!updatedTicket) {
  // Ticket was auto-expired/closed — load most recent so UI shows closed state
  const mostRecent = await getMostRecentTicket();
  setTicket(mostRecent);
  if (mostRecent?.id) await loadMessages(mostRecent.id);
}
```

`ticketStatus={ticket.status}` is now passed to `<TicketDivider>` at both render sites.

#### Patient Frontend — `TicketDivider.jsx`

Added `ticketStatus` prop. `getClosedByText()` now returns `'Auto-closed by System · 3 days inactivity'` when `closedBy === 'System'` or `ticketStatus === 'Expired'`, instead of the generic `'Ticket Closed by: System'`.

---

## 2. Appointment Queue — Date & Scheduler Filters

### Problem

The appointment queue had no server-side filtering by date or scheduler. Staff had to scroll through all appointments for a given status.

### Changes

#### Backend — `schema.graphql`

```graphql
# Before
searchAppointmentStatuses(status: SCHEDULING_STATUS!, location: LOCATION_DESIGNATION, offset: Int, limit: Int): [patientSlot!]

# After
searchAppointmentStatuses(status: SCHEDULING_STATUS!, location: LOCATION_DESIGNATION, date: Date, schedulerId: ID, offset: Int, limit: Int): [patientSlot!]
```

#### Backend — `wrapper.js` (`_searchAppointmentStatuses`)

- Added `$5::date` and `$6::integer` parameters for `date` and `schedulerId` filters using `COALESCE`-style null-passthrough (`$5::date IS NULL OR sde."scheduledDate"::date = $5::date`).
- Fixed a pre-existing table name bug: `"SlotScheduler"` → `"slotScheduler"` in the status counts query.
- Sort order changed from `ORDER BY ps.id DESC` to `ORDER BY sde."scheduledDate" ASC, ps.id DESC` so results are ordered chronologically when a date filter is active.

#### Backend — `medical-resolver.js`

Updated resolver signature to pass `date` and `schedulerId` through to the wrapper.

#### Staff Frontend — `staff-appointment-service.js`

`searchByStatus` now accepts an optional `{ date, schedulerId }` options object that is forwarded in the GraphQL query variables.

#### Staff Frontend — `appointment-queue.jsx`

- Added `filterDate` and `filterSchedulerId` state.
- Schedulers are fetched once on mount via `listAllSchedulers()` to populate the dropdown.
- Date input (with calendar icon and inline clear button) and scheduler `<select>` added to the filter bar.
- A "Clear Filters" button appears when either filter is active.
- All existing fetch calls (`fetchAppointments`, `handleLoadMore`, `handleTabChange`, refresh via `useImperativeHandle`) pass the current filter values.
- Empty state message distinguishes between "no results for active filters" and "no appointments at the moment".

---

## 3. Staff Dashboard — Live User Profile Display

### Problem

The staff sidebar avatar and top-bar user menu displayed hardcoded values ("DR" / "Dr. Staff" / "Medical Doctor") instead of real data for the logged-in user.

### Changes

#### Backend — `staff.js`

New REST endpoint `GET /staff/me/profile` (JWT-protected, `medical` role):

```
Returns: { email, name, firstName, lastName, role, branch, isActive }
```

Queries `UserCredentials`, `UsersPersonal`, and `MedicalPersonnel` in a single join. Middle name is abbreviated to initial if present.

#### Staff Frontend — `use-staff-profile.js` (new hook)

Module-level cache with 5-minute TTL shared across all hook instances. Concurrent calls de-duplicate into a single in-flight request. Exports `useStaffProfile()` and `clearStaffProfileCache()`.

```js
const { profile, isLoading, error, refetch } = useStaffProfile();
// profile: { email, name, firstName, lastName, role, branch, isActive }
```

#### Staff Frontend — `StaffSidebar.jsx`

- Avatar initial: `profile?.firstName?.[0] ?? profile?.email?.[0]?.toUpperCase() ?? 'S'`
- Display name: real email (truncated with tooltip)
- Subtitle: real `profile.role`

#### Staff Frontend — `StaffTopBar.jsx`

- Avatar initial: same formula as sidebar
- User dropdown expanded to `w-64` with structured sections: full name, email, role badge, branch badge
- `clearStaffProfileCache()` called on logout so the next session always fetches fresh data

---

## 4. Role Management — Admin Transfer Bootstrap Mode

### Problem

Admin transfer required both parties to have 2FA enabled before initiating a transfer. In fresh deployments where no admin has set up 2FA yet, the flow was completely blocked with no escape hatch.

### Changes

#### Backend — `wrapper.js` (`initiateAdminTransfer`)

When the environment variable `ALLOW_BOOTSTRAP_ADMIN=true` is set:

- The 2FA check for the target user is bypassed, logging an audit event of type `ADMIN_TRANSFER_BOOTSTRAP_BYPASS` instead of `ADMIN_TRANSFER_FAILED`.
- The 2FA check for the current admin is bypassed (this logic already existed for the current admin; extended to the target as well).

The `allowBootstrapAdmin` flag is now declared once at the top of the function and reused in both check locations (previously it was declared only for the old-admin check).

#### Backend — `schema.graphql`

Added `bootstrapMode: Boolean!` to `InitiateAdminTransferResult`.

#### Staff Frontend — `staff-service.js`

`GQL_INITIATE_ADMIN_TRANSFER` query updated to request `bootstrapMode`.

#### Staff Frontend — `admin-transfer.jsx`

New `'bootstrap'` step added to the transfer flow:

- When `result.bootstrapMode` is `true`, the UI navigates to the bootstrap step instead of the verify step.
- Bootstrap step shows a warning banner, a preview of the target staff member, and a direct "Confirm Transfer" button.
- `handleBootstrapConfirm` calls `confirmAdminTransfer('BOOTSTRAP_ADMIN_TRANSFER')` as the token.
- Success message updated: "You no longer have admin access. Please refresh the page." (removed the misleading "will redirect shortly" copy).

Flow diagram:

```
Initiate ──→ [bootstrapMode?] ─── yes ──→ Bootstrap confirm ──→ Success
                                └─ no  ──→ Email OTP verify  ──→ Success
```

---

## Files Changed

| File | Area | Type |
|------|------|------|
| `Backend/routes/health-chat/resolvers/wrapper/helper.js` | Health Chat | Fix + Refactor |
| `Backend/routes/health-chat/resolvers/wrapper/wrapper.js` | Health Chat | Fix |
| `mds-patient/src/modules/health-chat/health-chat.jsx` | Health Chat | Fix |
| `mds-patient/src/modules/health-chat/components/TicketDivider.jsx` | Health Chat | Enhancement |
| `Backend/routes/appointment/schema.graphql` | Appointment | Enhancement |
| `Backend/routes/appointment/resolvers/wrapper/wrapper.js` | Appointment | Enhancement + Fix |
| `Backend/routes/appointment/resolvers/medical/medical-resolver.js` | Appointment | Enhancement |
| `mds-staff/src/modules/appointment/staff-appointment-service.js` | Appointment | Enhancement |
| `mds-staff/src/modules/appointment/components/appointment-queue.jsx` | Appointment | Enhancement |
| `Backend/routes/staff/staff.js` | Staff Profile | Feature |
| `mds-staff/src/hooks/use-staff-profile.js` _(new)_ | Staff Profile | Feature |
| `mds-staff/src/components/layout/StaffSidebar.jsx` | Staff Profile | Feature |
| `mds-staff/src/components/layout/StaffTopBar.jsx` | Staff Profile | Feature |
| `Backend/routes/role-management/schema.graphql` | Role Management | Enhancement |
| `Backend/routes/role-management/resolvers/wrapper/wrapper.js` | Role Management | Enhancement |
| `mds-staff/src/modules/role-management/staff-service.js` | Role Management | Enhancement |
| `mds-staff/src/modules/role-management/components/admin-transfer.jsx` | Role Management | Enhancement |

**Total:** 17 files, +577 / −94 lines

---

## Testing Notes

> From @K1taru: "fix_optimization(Appointment, Health-Chat, Role-Management): I haven't tested them yet, please test ty"

The following scenarios require manual verification:

### Health Chat
- [ ] Patient with an `Ongoing` ticket older than 3 days: should auto-expire on next page load, not block new ticket creation
- [ ] Patient with an `Open` (pending) ticket older than 3 days: should auto-expire, `TicketDivider` shows "Auto-closed by System · 3 days inactivity"
- [ ] Patient with an `Open` ticket while their account is `Expired` in `UserCredentials`: auto-expires immediately
- [ ] Patient closing own ticket on an already-expired ticket: should receive 400, not silently overwrite
- [ ] Patient with mid-session auto-expiry: polling detects null active ticket, loads most-recent, shows closed state, "New Consultation" button appears

### Appointment
- [ ] Filter by date: only appointments for that scheduled date appear
- [ ] Filter by scheduler: only appointments for that scheduler appear
- [ ] Combined filters work correctly
- [ ] Clearing filters restores full list
- [ ] Pagination ("Load More") respects active filters
- [ ] Empty state message says "Try adjusting or clearing the active filters" when filters are active
- [ ] `getAppointmentStatusCounts` no longer errors (was using wrong table name `"SlotScheduler"` → `"slotScheduler"`)

### Staff Profile
- [ ] Sidebar avatar initial shows correct first letter of first name (or email fallback)
- [ ] Sidebar shows real email and role when expanded
- [ ] Top-bar dropdown shows full name, email, role badge, branch badge
- [ ] Cache is cleared on logout; next login fetches fresh data

### Role Management — Admin Transfer
- [ ] Without `ALLOW_BOOTSTRAP_ADMIN=true`: flow unchanged, 2FA required for both parties
- [ ] With `ALLOW_BOOTSTRAP_ADMIN=true`: bootstrap step is shown, transfer completes without 2FA
- [ ] Audit log records `ADMIN_TRANSFER_BOOTSTRAP_BYPASS` event in bootstrap mode
- [ ] Success screen no longer says "will redirect shortly"
