### PR TITLE
appointment: prevent accidental schedule creation; add custom-date disable/reset

### DIFF
--- a/Backend/config/sockets/notification-events.js
+++ b/Backend/config/sockets/notification-events.js
@@ -82,6 +82,7 @@ const notificationHandlers = {
       if (typeof ack === 'function') ack({ error: 'INTERNAL_ERROR', message: err.message });
     }
   },
+
 };
 
 registerHandlers(notificationHandlers);

--- a/Backend/routes/appointment/resolvers/wrapper/wrapper.js
+++ b/Backend/routes/appointment/resolvers/wrapper/wrapper.js
@@ -1477,13 +1477,35 @@ const Mutation = {
         RETURNING *;
       `;
 
-      const result = await db.query(query, values);
+      let result = await db.query(query, values);
 
+      // If no entity exists yet, create one with scheduler defaults then retry
       if (result.rowCount === 0) {
-        throwGraphQLError(res)
-          .message("No matching schedule date entity found to update")
-          .status(404)
-          .throw();
+        const schedulerDefaults = await db.query(
+          `SELECT "morningAllowed", "afternoonAllowed" FROM "slotScheduler" WHERE id = $1;`,
+          [schedulerId]
+        );
+        if (schedulerDefaults.rowCount === 0) {
+          throwGraphQLError(res).message("Scheduler not found").status(404).throw();
+        }
+        const { morningAllowed: defMorning, afternoonAllowed: defAfternoon } = schedulerDefaults.rows[0];
+
+        await db.query(
+          `INSERT INTO "ScheduleDateEntity" ("slotId", "scheduledDate", "morningAllowed", "afternoonAllowed")
+           SELECT $1, $2, $3, $4
+           WHERE NOT EXISTS (
+             SELECT 1 FROM "ScheduleDateEntity" WHERE "slotId" = $1 AND "scheduledDate" = $2
+           );`,
+          [schedulerId, date, defMorning, defAfternoon]
+        );
+
+        result = await db.query(query, values);
+        if (result.rowCount === 0) {
+          throwGraphQLError(res)
+            .message("Failed to create and update schedule date entity")
+            .status(500)
+            .throw();
+        }
       }
 
       // Attach computed counts so GraphQL can resolve morningRegistered, etc.

--- a/mds-patient/src/modules/appointment/components/ReviewSubmit.jsx
+++ b/mds-patient/src/modules/appointment/components/ReviewSubmit.jsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { Spinner, BackButton } from './shared';
 import { SESSION } from '../patient-appointment-service';
 
-const ReviewSubmit = ({ scheduler, selectedDate, selectedSession, requirements, uploadedFiles, purpose, onPurposeChange, submitting, onSubmit, onBack }) => (
+const ReviewSubmit = ({ scheduler, selectedDate, selectedSession, requirements, uploadedFiles, purpose, onPurposeChange, submitting, onSubmit, onBack }) => {
+  const purposeRequired = scheduler?.purposeRequired ?? false;
+  return (
   <div className="bg-white dark:bg-neutral-900 rounded-lg shadow-lg p-6">
     <h2 className="text-xl font-semibold text-neutral-900 dark:text-white mb-6">Review &amp; Submit</h2>
     <div className="space-y-3 mb-6">
@@ -42,15 +44,26 @@ const ReviewSubmit = ({ scheduler, selectedDate, selectedSession, requirements, 
     {/* Purpose / Reason for Visit */}
     <div className="mb-6 pt-4 border-t border-neutral-200 dark:border-neutral-700">
       <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
-        Purpose / Reason for Visit <span className="text-neutral-400 text-xs">({(purpose || '').length}/250)</span>
+        Purpose / Reason for Visit
+        {purposeRequired
+          ? <span className="text-red-500 ml-0.5">*</span>
+          : null}
+        {' '}<span className="text-neutral-400 text-xs">({purposeRequired ? 'Required' : 'optional'} · {(purpose || '').length}/250)</span>
       </label>
       <textarea
         maxLength={250}
         rows={3}
+        required={purposeRequired}
         value={purpose || ''}
         onChange={(e) => onPurposeChange(e.target.value.slice(0, 250))}
-        placeholder="Briefly describe the reason for your appointment (optional)"
-        className="w-full px-3 py-2 text-sm rounded-lg border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-white placeholder-neutral-400 dark:placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-primary-500 resize-none"
+        placeholder={purposeRequired
+          ? 'Briefly describe the reason for your appointment (Required)'
+          : 'Briefly describe the reason for your appointment (optional)'}
+        className={`w-full px-3 py-2 text-sm rounded-lg border bg-white dark:bg-neutral-800 text-neutral-900 dark:text-white placeholder-neutral-400 dark:placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-primary-500 resize-none ${
+          purposeRequired && !(purpose || '').trim()
+            ? 'border-red-400 dark:border-red-600'
+            : 'border-neutral-300 dark:border-neutral-600'
+        }`}
       />
     </div>
 
@@ -59,7 +72,7 @@ const ReviewSubmit = ({ scheduler, selectedDate, selectedSession, requirements, 
       <BackButton onClick={onBack} />
       <button
         onClick={onSubmit}
-        disabled={submitting}
+        disabled={submitting || (purposeRequired && !(purpose || '').trim())}
         className="px-6 py-3 bg-primary-600 hover:bg-primary-700 text-white font-medium rounded-lg transition-all shadow-lg hover:shadow-xl disabled:opacity-50 disabled:cursor-not-allowed flex items-center space-x-2"
       >
         {submitting && <Spinner />}
@@ -67,6 +80,7 @@ const ReviewSubmit = ({ scheduler, selectedDate, selectedSession, requirements, 
       </button>
     </div>
   </div>
-);
+  );
+};
 
 export default ReviewSubmit;

--- a/mds-staff/src/modules/appointment/components/appointment-queue.jsx
+++ b/mds-staff/src/modules/appointment/components/appointment-queue.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef, forwardRef, useImperativeHandle } from 'react';
-import { searchByStatus, getStatusCounts, listAllSchedulers } from '../staff-appointment-service';
+import { searchByStatus, getStatusCounts, listAllSchedulers, loadInitialQueueData } from '../staff-appointment-service';
 
 /* ── constants ─────────────────────────────────────── */
 
@@ -144,35 +144,63 @@ const AppointmentQueue = forwardRef(({ onViewDetails }, ref) => {
     },
   }), [activeTab, fetchAppointments, refreshCounts, filterDate, filterSchedulerId, filterLocation]);
 
-  /* Load schedulers once on mount for the filter dropdown */
+  /* Initial load — combines schedulers + counts + first-page appointments into
+     a single HTTP request to minimise round-trips on a low-power server.
+     Subsequent tab/filter changes use the individual fetchers below. */
+  const isInitialLoad = useRef(true);
   useEffect(() => {
-    listAllSchedulers().then(setSchedulers).catch(() => {});
-  }, []);
-
-  /* Load status counts — on mount and whenever filters change.
-     filterDate/filterSchedulerId default to '' which coerces to null
-     in refreshCounts ('' || null), so "all schedulers / all dates" is
-     handled correctly by the backend when no filter is selected. */
-  const isFirstCountFetch = useRef(true);
-  useEffect(() => {
+    let cancelled = false;
     const run = async () => {
-      if (isFirstCountFetch.current) {
-        isFirstCountFetch.current = false;
-        setLoadingCounts(true);
-        try {
-          await refreshCounts(filterDate, filterSchedulerId, filterLocation);
-        } finally {
+      const gen = ++fetchGenRef.current;
+      setLoading(true);
+      setLoadingCounts(true);
+      setHasMore(false);
+      setOffset(0);
+      try {
+        const result = await loadInitialQueueData(
+          activeTab,
+          PAGE_SIZE,
+          { date: filterDate || null, schedulerId: filterSchedulerId || null, location: filterLocation || null }
+        );
+        if (cancelled || gen !== fetchGenRef.current) return;
+        setSchedulers(result.schedulers);
+        setTabCounts(result.counts);
+        setAppointments(result.appointments);
+        setHasMore(result.appointments.length === PAGE_SIZE);
+      } catch (err) {
+        if (cancelled || gen !== fetchGenRef.current) return;
+        console.error('Failed to load initial queue data:', err);
+        setAppointments([]);
+        setHasMore(false);
+      } finally {
+        if (!cancelled && gen === fetchGenRef.current) {
+          setLoading(false);
           setLoadingCounts(false);
         }
-      } else {
-        refreshCounts(filterDate, filterSchedulerId, filterLocation);
       }
     };
     run();
-  }, [filterDate, filterSchedulerId, filterLocation, refreshCounts]);
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  /* Fetch appointments whenever the active tab or active filters change */
+  /* Re-fetch everything when filters change (after initial mount) */
   useEffect(() => {
+    if (isInitialLoad.current) {
+      isInitialLoad.current = false;
+      return;
+    }
+    fetchAppointments(activeTab, filterDate, filterSchedulerId, filterLocation);
+    refreshCounts(filterDate, filterSchedulerId, filterLocation);
+  }, [filterDate, filterSchedulerId, filterLocation, refreshCounts, fetchAppointments]);
+
+  /* Re-fetch appointments when tab changes (after initial mount) */
+  const isInitialTabRender = useRef(true);
+  useEffect(() => {
+    if (isInitialTabRender.current) {
+      isInitialTabRender.current = false;
+      return;
+    }
     fetchAppointments(activeTab, filterDate, filterSchedulerId, filterLocation);
   }, [activeTab, filterDate, filterSchedulerId, filterLocation, fetchAppointments]);
 

--- a/mds-staff/src/modules/appointment/components/availability-calendar.jsx
+++ b/mds-staff/src/modules/appointment/components/availability-calendar.jsx
@@ -95,8 +95,6 @@ const AvailabilityCalendar = ({ selectedDate, onSelectDate, events, slotDefaults
       const dayName = dayIndexToName[dayOfWeek];
       if (currentSchedulePerWeek.includes(dayName)) return true;
       if (customDateSet.has(dateStr)) return true;
-      // Also consider dates that have API data (ScheduleDateEntity exists)
-      if (monthAvailability[dateStr]) return true;
       return false;
     };
 

--- a/mds-staff/src/modules/appointment/components/availability-manager.jsx
+++ b/mds-staff/src/modules/appointment/components/availability-manager.jsx
@@ -195,29 +195,24 @@ const AvailabilityManager = () => {
     }
   };
 
-  // Handle calendar date selection - load day-specific data (allow all dates)
-  const handleDateSelect = async (dateStr, isAvailable = true) => {
+  // Handle calendar date selection — read-only, never creates DB rows
+  const handleDateSelect = (dateStr) => {
     setSelectedCalendarDate(dateStr);
     if (!activeScheduler?.id || !dateStr) {
       setDayOverrideData(null);
       return;
     }
 
-    // Load override data for any date (staff can view/edit all dates)
-    setLoadingDayData(true);
-    try {
-      const data = await getScheduleAvailability(activeScheduler.id, dateStr);
-      setDayOverrideData(data);
-      // Refresh month availability since getScheduleAvailability may create a new ScheduleDateEntity
-      if (currentMonthRange) {
-        loadMonthAvailability(activeScheduler.id, currentMonthRange.startDate, currentMonthRange.endDate);
-      }
-    } catch (err) {
-      console.error('Failed to load day data:', err);
+    // For closed dates: show the "Add as custom date" prompt
+    if (!isDateAvailable(dateStr)) {
       setDayOverrideData(null);
-    } finally {
-      setLoadingDayData(false);
+      return;
     }
+
+    // Use already-loaded monthAvailability data (no API call = no ScheduleDateEntity creation)
+    // For dates without an entity yet, dayOverrideData stays null and DaySlotEditor
+    // falls back to scheduler defaults.
+    setDayOverrideData(monthAvailability[dateStr] || null);
   };
 
   // Check if a specific date is available (in schedule or custom dates)
@@ -306,11 +301,10 @@ const AvailabilityManager = () => {
       const input = session === 'morning'
         ? { morningAllowed: value }
         : { afternoonAllowed: value };
-      await updateDateIdentity(activeScheduler.id, dateStr, input);
-      // If this is the currently selected date, refresh the day data
+      const result = await updateDateIdentity(activeScheduler.id, dateStr, input);
+      // Update the day slot editor if this is the currently selected date
       if (dateStr === selectedCalendarDate) {
-        const data = await getScheduleAvailability(activeScheduler.id, dateStr);
-        setDayOverrideData(data);
+        setDayOverrideData(result);
       }
       // Refresh month availability to update calendar view
       if (currentMonthRange) {
@@ -319,6 +313,40 @@ const AvailabilityManager = () => {
     } catch (err) {
       setError(err.message || 'Failed to update session limit');
       throw err;
+    }
+  };
+
+  // Handle disabling a date (set both sessions to 0)
+  const handleDisableDate = async (dateStr) => {
+    if (!activeScheduler?.id || !dateStr) return;
+    try {
+      const result = await updateDateIdentity(activeScheduler.id, dateStr, {
+        morningAllowed: 0,
+        afternoonAllowed: 0,
+      });
+      setDayOverrideData(result);
+      if (currentMonthRange) {
+        loadMonthAvailability(activeScheduler.id, currentMonthRange.startDate, currentMonthRange.endDate);
+      }
+    } catch (err) {
+      setError(err.message || 'Failed to disable date');
+    }
+  };
+
+  // Handle re-enabling a disabled date (reset to scheduler defaults)
+  const handleResetDate = async (dateStr) => {
+    if (!activeScheduler?.id || !dateStr) return;
+    try {
+      const result = await updateDateIdentity(activeScheduler.id, dateStr, {
+        morningAllowed: activeScheduler.morningAllowed,
+        afternoonAllowed: activeScheduler.afternoonAllowed,
+      });
+      setDayOverrideData(result);
+      if (currentMonthRange) {
+        loadMonthAvailability(activeScheduler.id, currentMonthRange.startDate, currentMonthRange.endDate);
+      }
+    } catch (err) {
+      setError(err.message || 'Failed to reset date');
     }
   };
 
@@ -372,6 +400,7 @@ const AvailabilityManager = () => {
       notes: '',
       isActive: true,
       whitelistOnly: false,
+      purposeRequired: false,
     });
     setRequirements([]);
     setPendingRequirements([]);
@@ -476,6 +505,7 @@ const AvailabilityManager = () => {
           notes: editForm.notes || null,
           isActive: editForm.isActive,
           whitelistOnly: editForm.whitelistOnly,
+          purposeRequired: editForm.purposeRequired ?? false,
         });
         await loadSchedulers(updated?.id ?? editForm.id);
       } else {
@@ -489,6 +519,7 @@ const AvailabilityManager = () => {
           afternoonAllowed: editForm.afternoonAllowed,
           notes: editForm.notes || null,
           whitelistOnly: editForm.whitelistOnly ?? false,
+          purposeRequired: editForm.purposeRequired ?? false,
           slotCustomDates: [],
           whiteLists: [],
         });
@@ -784,9 +815,11 @@ const AvailabilityManager = () => {
                 loading={loadingDayData}
                 events={events}
                 customDates={customDates}
-                isDateAvailable={selectedCalendarDate ? (isDateAvailable(selectedCalendarDate) || !!dayOverrideData) : false}
+                isDateAvailable={selectedCalendarDate ? isDateAvailable(selectedCalendarDate) : false}
                 onAddCustomDate={handleAddCustomDateFromEditor}
                 onRemoveCustomDate={handleRemoveCustomDateFromEditor}
+                onDisableDate={handleDisableDate}
+                onResetDate={handleResetDate}
               />
             )}
 
@@ -1115,6 +1148,18 @@ const AvailabilityManager = () => {
                       <div>
                         <p className="text-sm font-medium text-secondary-700 dark:text-neutral-300 leading-tight">Active</p>
                         <p className="text-xs text-secondary-500 dark:text-neutral-400 leading-tight">Open and accepting appointments</p>
+                      </div>
+                    </label>
+                    <label className="flex items-center gap-2 p-1 bg-neutral-50 dark:bg-neutral-700/50 rounded cursor-pointer hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors">
+                      <input
+                        type="checkbox"
+                        checked={editForm.purposeRequired ?? false}
+                        onChange={(e) => setEditForm({ ...editForm, purposeRequired: e.target.checked })}
+                        className="w-3.5 h-3.5 text-primary-500 border-neutral-300 dark:border-neutral-600 rounded focus:ring-primary-500"
+                      />
+                      <div>
+                        <p className="text-sm font-medium text-secondary-700 dark:text-neutral-300 leading-tight">Require Purpose</p>
+                        <p className="text-xs text-secondary-500 dark:text-neutral-400 leading-tight">Patients must provide a reason for their visit</p>
                       </div>
                     </label>
                     <label className="flex items-center gap-2 p-1 bg-neutral-50 dark:bg-neutral-700/50 rounded cursor-pointer hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors">

--- a/mds-staff/src/modules/appointment/components/day-slot-editor.jsx
+++ b/mds-staff/src/modules/appointment/components/day-slot-editor.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { Sun, Moon, Plus, Minus, X, Check, Calendar, Trash2, Clock } from 'lucide-react';
+import { Sun, Moon, Plus, Minus, X, Check, Calendar, Trash2, Clock, Ban, RotateCcw } from 'lucide-react';
 
 /**
  * Normalize a date value (string, Date, or number) to YYYY-MM-DD format.
@@ -33,6 +33,8 @@ const DaySlotEditor = ({
   isDateAvailable = true,
   onAddCustomDate,
   onRemoveCustomDate,
+  onDisableDate,
+  onResetDate,
 }) => {
   const selectedDate = normalizeDate(rawSelectedDate);
   const [morningSlots, setMorningSlots] = useState(0);
@@ -119,6 +121,31 @@ const DaySlotEditor = ({
     }
   };
 
+  const handleDisableDate = async () => {
+    if (onDisableDate) {
+      setSaving(true);
+      try {
+        await onDisableDate(selectedDate);
+      } finally {
+        setSaving(false);
+      }
+    }
+  };
+
+  const handleResetDate = async () => {
+    if (onResetDate) {
+      setSaving(true);
+      try {
+        await onResetDate(selectedDate);
+      } finally {
+        setSaving(false);
+      }
+    }
+  };
+
+  // Check if date is explicitly disabled (both sessions = 0)
+  const isExplicitlyDisabled = isDateAvailable && displayMorning === 0 && displayAfternoon === 0;
+
   const formatDateShort = (dateStr) => {
     if (!dateStr) return '';
     const normalized = normalizeDate(dateStr);
@@ -185,7 +212,7 @@ const DaySlotEditor = ({
                 </span>
               </div>
               <p className="text-xs text-secondary-400 dark:text-neutral-500 ml-5">
-                {getDayOfWeek(selectedDate)} is not in the schedule. Enable it to accept appointments.
+                {getDayOfWeek(selectedDate)} is not in the regular schedule. Add it as a custom date to accept appointments.
               </p>
             </div>
             <button
@@ -198,8 +225,55 @@ const DaySlotEditor = ({
               ) : (
                 <Plus className="w-3 h-3" />
               )}
-              Enable
+              Add Custom Date
             </button>
+          </div>
+        </div>
+      ) : isExplicitlyDisabled ? (
+        /* Disabled day - re-enable */
+        <div className="flex-1 flex flex-col justify-center px-3 py-2">
+          <div className="flex items-center justify-between">
+            <div className="min-w-0">
+              <div className="flex items-center gap-1.5 mb-0.5">
+                <Ban className="w-3.5 h-3.5 text-rose-400 flex-shrink-0" />
+                <span className="text-sm font-semibold text-secondary-800 dark:text-white truncate">{formatDateShort(selectedDate)}</span>
+                <span className="px-1.5 py-px text-xs font-semibold bg-rose-100 dark:bg-rose-900/30 text-rose-600 dark:text-rose-400 rounded-full uppercase">
+                  Disabled
+                </span>
+                {isCustomDate && (
+                  <span className="px-1.5 py-px text-xs font-semibold bg-violet-100 dark:bg-violet-900/30 text-violet-600 dark:text-violet-400 rounded-full flex-shrink-0">
+                    Custom
+                  </span>
+                )}
+              </div>
+              <p className="text-xs text-secondary-400 dark:text-neutral-500 ml-5">
+                This date is disabled. Patients cannot book appointments on this day.
+              </p>
+            </div>
+            <div className="flex items-center gap-1 flex-shrink-0 ml-2">
+              <button
+                onClick={handleResetDate}
+                disabled={saving}
+                className="flex items-center gap-1 px-2.5 py-1.5 text-xs font-semibold text-white bg-emerald-500 hover:bg-emerald-600 rounded-lg transition-colors disabled:opacity-50 shadow-sm"
+              >
+                {saving ? (
+                  <div className="w-3 h-3 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                ) : (
+                  <RotateCcw className="w-3 h-3" />
+                )}
+                Re-enable
+              </button>
+              {isCustomDate && (
+                <button
+                  onClick={handleRemoveAsCustomDate}
+                  disabled={saving}
+                  className="p-1 text-error-400 hover:text-error-600 hover:bg-error-50 dark:hover:bg-error-900/20 rounded transition-colors disabled:opacity-50"
+                  title="Remove custom date"
+                >
+                  <Trash2 className="w-3.5 h-3.5" />
+                </button>
+              )}
+            </div>
           </div>
         </div>
       ) : (
@@ -236,6 +310,14 @@ const DaySlotEditor = ({
                   Save
                 </button>
               )}
+              <button
+                onClick={handleDisableDate}
+                disabled={saving}
+                className="p-1 text-neutral-400 hover:text-rose-500 hover:bg-rose-50 dark:hover:bg-rose-900/20 rounded transition-colors disabled:opacity-50"
+                title="Disable this date"
+              >
+                <Ban className="w-3.5 h-3.5" />
+              </button>
               {isCustomDate && (
                 <button
                   onClick={handleRemoveAsCustomDate}

--- a/mds-staff/src/modules/appointment/components/scheduler-modal.jsx
+++ b/mds-staff/src/modules/appointment/components/scheduler-modal.jsx
@@ -256,18 +256,31 @@ const SchedulerModal = ({ isOpen, onClose, onSave, onDelete, editingScheduler })
             />
           </div>
 
-          {/* Active toggle (edit only) */}
-          {isEditing && (
+          {/* Toggles */}
+          <div className="flex flex-col gap-1.5">
+            {isEditing && (
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={formData.isActive}
+                  onChange={(e) => setFormData((prev) => ({ ...prev, isActive: e.target.checked }))}
+                  className="w-4 h-4 rounded border-neutral-300 text-primary-500 focus:ring-primary-500"
+                />
+                <span className="text-base text-secondary-700 dark:text-neutral-300">Active</span>
+              </label>
+            )}
             <label className="flex items-center gap-2 cursor-pointer">
               <input
                 type="checkbox"
-                checked={formData.isActive}
-                onChange={(e) => setFormData((prev) => ({ ...prev, isActive: e.target.checked }))}
+                checked={formData.purposeRequired}
+                onChange={(e) => setFormData((prev) => ({ ...prev, purposeRequired: e.target.checked }))}
                 className="w-4 h-4 rounded border-neutral-300 text-primary-500 focus:ring-primary-500"
               />
-              <span className="text-base text-secondary-700 dark:text-neutral-300">Active</span>
+              <span className="text-base text-secondary-700 dark:text-neutral-300">
+                Require Purpose / Reason for Visit
+              </span>
             </label>
-          )}
+          </div>
 
           {/* ── Requirements ───────────────────────────────────────────── */}
           <div className="border border-neutral-200 dark:border-neutral-700 rounded-lg overflow-hidden">
@@ -407,6 +420,7 @@ function getDefaults(scheduler) {
     notes: scheduler?.notes || '',
     isActive: scheduler?.isActive ?? true,
     whitelistOnly: scheduler?.whitelistOnly ?? false,
+    purposeRequired: scheduler?.purposeRequired ?? false,
   };
 }
 

--- a/mds-staff/src/modules/appointment/staff-appointment-service.js
+++ b/mds-staff/src/modules/appointment/staff-appointment-service.js
@@ -126,6 +126,84 @@ export const getStatusCounts = async ({ schedulerId, date, location } = {}) => {
 };
 
 /**
+ * Load the queue's initial data in a single GraphQL request:
+ *   - status counts (tab badges)
+ *   - scheduler list (filter dropdown)
+ *   - first page of appointments for the given status
+ *
+ * Reduces 3 separate HTTP round-trips to 1.
+ *
+ * @param {string} status - Active tab's SCHEDULING_STATUS
+ * @param {number} [limit=15]
+ * @param {{ date?: string, schedulerId?: string, location?: string }} [filters]
+ * @returns {Promise<{ appointments: Array, counts: Object, schedulers: Array }>}
+ */
+export const loadInitialQueueData = async (status, limit = 15, { date, schedulerId, location } = {}) => {
+  const data = await sendGraphQL(`
+    query LoadInitialQueue(
+      $status: SCHEDULING_STATUS!, $limit: Int,
+      $date: Date, $schedulerId: ID, $location: LOCATION_DESIGNATION
+    ) {
+      appointments: searchAppointmentStatuses(
+        status: $status, offset: 0, limit: $limit,
+        date: $date, schedulerId: $schedulerId, location: $location
+      ) {
+        id
+        patientId
+        patientIdentifier
+        patientName
+        patientEmail
+        slotEntityId
+        status
+        session
+        scheduledDate
+        schedulerLabel
+        approvedBy
+        purpose
+        notes
+        arrived_at
+        created_at
+        requirements {
+          id
+          scheduleRequirementId
+          filename
+          created_at
+        }
+      }
+      counts: getAppointmentStatusCounts(date: $date, schedulerId: $schedulerId, location: $location) {
+        status
+        count
+      }
+      schedulers: listAllOpenAppointments(offset: 0, limit: 200) {
+        id
+        label
+        location
+        patientType
+        schedulePerWeek
+        morningAllowed
+        afternoonAllowed
+        notes
+        isActive
+        containsCustomDates
+        whitelistOnly
+        created_at
+      }
+    }
+  `, { status, limit, date: date || null, schedulerId: schedulerId || null, location: location || null });
+
+  const counts = {};
+  for (const { status: s, count } of data.counts) {
+    counts[s] = count;
+  }
+
+  return {
+    appointments: data.appointments || [],
+    counts,
+    schedulers: data.schedulers || [],
+  };
+};
+
+/**
  * Get a specific patient's current appointment status.
  * @param {string} userId
  * @returns {Promise<string|null>}

--- a/mds-staff/src/modules/notification/notification-context.jsx
+++ b/mds-staff/src/modules/notification/notification-context.jsx
@@ -452,8 +452,13 @@ export function StaffNotificationProvider({ children }) {
   const unseenInventoryCount = inventoryAlerts.filter((a) => !seenInventoryIds.has(a.id)).length;
   const unreadCount = notifications.filter((n) => n.unread).length + unseenInventoryCount;
 
+  /** Emit a raw socket event (e.g. to join/leave a server-side room). */
+  const emit = useCallback((event, data) => {
+    socketRef.current?.emit(event, data);
+  }, []);
+
   return (
-    <NotificationContext.Provider value={{ notifications, unreadCount, markAsRead, markAllAsRead, clearAll, clearNotificationsByType, removeNotificationByRefId, subscribe, inventoryAlerts, markInventoryAlertsAsSeen, refreshInventoryAlerts }}>
+    <NotificationContext.Provider value={{ notifications, unreadCount, markAsRead, markAllAsRead, clearAll, clearNotificationsByType, removeNotificationByRefId, subscribe, emit, inventoryAlerts, markInventoryAlertsAsSeen, refreshInventoryAlerts }}>
       {children}
     </NotificationContext.Provider>
   );


### PR DESCRIPTION
appointment: prevent accidental schedule creation; add custom-date disable/reset

Prevent accidental creation of ScheduleDateEntity rows when staff click non-scheduled calendar dates by making date selection read-only and relying on month availability for display. Remove ghost-enabled dates that persisted after scheduleFlags changes. Add an explicit ' Add Custom Date' flow and clarify DaySlotEditor copy. Introduce per-date Disable and Re-enable actions (sets morning/afternoon to 0 or resets to scheduler defaults) and a Remove custom date action that fully deletes SlotCustomDate and associated ScheduleDateEntity when safe. Backend now upserts ScheduleDateEntity in updateDateIdentity so edits succeed on previously-unseen dates. Cleaned calendar logic and session-edit paths.