### PR TITLE
feat(analytics): add demographic analytics with sex, age, department, program dimensions

### DIFF
--- a/Backend/routes/analytics/analytics.js
+++ b/Backend/routes/analytics/analytics.js
@@ -1,10 +1,10 @@
 const express = require('express');
-const logger = require('../../../utils/logger.js');
-const { jwtProtect } = require('../../../config/middleware/jwtProtect.js');
-const query = require('../../../config/query.js');
-const analytics = require('../../../services/analytics-query.js');
-const docGen = require('../../../services/doc-generate-module/index.js');
-const analyticsExport = require('../../../services/analytics-export.js');
+const logger = require('../../utils/logger.js');
+const { jwtProtect } = require('../../config/middleware/jwtProtect.js');
+const query = require('../../config/query.js');
+const analytics = require('../../services/analytics-query.js');
+const docGen = require('../../services/doc-generate-module/index.js');
+const analyticsExport = require('../../services/analytics-export.js');
 
 const router = express.Router();
 
@@ -218,7 +218,7 @@ router.get('/report/:reportType', jwtProtect('medical'), async (req, res) => {
     const reportData = await analytics.getReportData(reportType, branch, startDate, endDate);
 
     // Fetch physician info
-    const physicianResult = await require('../../../config/db.js').query(
+    const physicianResult = await require('../../config/db.js').query(
       `SELECT up.first_name, up.last_name, mp.title
        FROM "UsersPersonal" up
        LEFT JOIN "MedicalPersonnel" mp ON up.id = mp.id
@@ -400,7 +400,7 @@ router.post('/export', jwtProtect('medical'), async (req, res) => {
     // ── PDF ──────────────────────────────────────────────────
     if (format === 'pdf') {
       // Fetch physician info for PDF signature
-      const physicianResult = await require('../../../config/db.js').query(
+      const physicianResult = await require('../../config/db.js').query(
         `SELECT up.first_name, up.last_name, mp.title
          FROM "UsersPersonal" up
          LEFT JOIN "MedicalPersonnel" mp ON up.id = mp.id
@@ -484,7 +484,7 @@ router.post('/export/single', jwtProtect('medical'), async (req, res) => {
     }
 
     // Fetch physician info
-    const physicianResult = await require('../../../config/db.js').query(
+    const physicianResult = await require('../../config/db.js').query(
       `SELECT up.first_name, up.last_name, mp.title
        FROM "UsersPersonal" up
        LEFT JOIN "MedicalPersonnel" mp ON up.id = mp.id

--- a/Backend/services/analytics-export.js
+++ b/Backend/services/analytics-export.js
@@ -29,6 +29,20 @@ const EXPORT_META = {
   'appointments-by-category': { label: 'Appointments by Category',    xAxis: 'Category',      yAxis: 'Count',   chartType: 'pie' },
   'appointments-by-status':   { label: 'Appointments by Status',      xAxis: 'Status',        yAxis: 'Count',   chartType: 'doughnut' },
   'appointments-by-session':  { label: 'Appointments by Session',     xAxis: 'Session',       yAxis: 'Count',   chartType: 'pie' },
+
+  // Demographics
+  'patients-by-sex':              { label: 'Patients by Sex',                xAxis: 'Sex',             yAxis: 'Patients', chartType: 'bar' },
+  'consultations-by-sex':         { label: 'Consultations by Sex',           xAxis: 'Sex',             yAxis: 'Count',    chartType: 'bar' },
+  'top-diagnoses-by-sex':         { label: 'Top Diagnoses by Sex',           xAxis: 'Diagnosis',       yAxis: 'Count',    chartType: 'bar', hasSeries: true },
+  'patients-by-age-group':        { label: 'Patients by Age Group',          xAxis: 'Age Group',       yAxis: 'Patients', chartType: 'bar' },
+  'consultations-by-age-group':   { label: 'Consultations by Age Group',     xAxis: 'Age Group',       yAxis: 'Count',    chartType: 'bar' },
+  'bmi-by-age-group':             { label: 'Average BMI by Age Group',       xAxis: 'Age Group',       yAxis: 'Avg BMI',  chartType: 'bar' },
+  'diagnoses-by-age-group':       { label: 'Diagnoses by Age Group',         xAxis: 'Age Group',       yAxis: 'Count',    chartType: 'bar', hasSeries: true },
+  'consultations-by-department':  { label: 'Consultations by Department',    xAxis: 'Department',      yAxis: 'Count',    chartType: 'bar' },
+  'consultations-by-program':     { label: 'Consultations by Program',       xAxis: 'Program',         yAxis: 'Count',    chartType: 'bar' },
+  'lifestyle-risks-by-department':{ label: 'Lifestyle Risks by Department',  xAxis: 'Department',      yAxis: 'Count',    chartType: 'bar', hasSeries: true },
+  'sex-age-group-matrix':         { label: 'Sex × Age Group Matrix',         xAxis: 'Age Group',       yAxis: 'Count',    chartType: 'bar', hasSeries: true },
+  'diagnoses-sex-age':            { label: 'Diagnoses by Sex & Age',         xAxis: 'Diagnosis',       yAxis: 'Count',    chartType: 'bar', hasSeries: true },
 };
 
 /**
@@ -37,7 +51,7 @@ const EXPORT_META = {
 const EXPORT_PRESETS = {
   'full-report': {
     label: 'Full Analytics Report',
-    description: 'All 15 analytics metrics combined',
+    description: 'All analytics metrics combined',
     dataTypes: Object.keys(EXPORT_META),
   },
   'consultations': {
@@ -69,6 +83,16 @@ const EXPORT_PRESETS = {
     label: 'Lifestyle & Allergies Report',
     description: 'Lifestyle risk factors and allergy data',
     dataTypes: ['lifestyle-risks', 'allergy-by-type', 'allergy-by-severity'],
+  },
+  'demographics': {
+    label: 'Demographics Report',
+    description: 'Sex, age group, department, and program distribution analytics',
+    dataTypes: [
+      'patients-by-sex', 'consultations-by-sex', 'top-diagnoses-by-sex',
+      'patients-by-age-group', 'consultations-by-age-group', 'bmi-by-age-group', 'diagnoses-by-age-group',
+      'consultations-by-department', 'consultations-by-program', 'lifestyle-risks-by-department',
+      'sex-age-group-matrix', 'diagnoses-sex-age',
+    ],
   },
 };
 
@@ -165,11 +189,22 @@ function generateCSV(data, meta) {
     if (!meta_ || !result.labels) continue;
 
     lines.push(`# ${meta_.label}`);
-    lines.push(`${csvEscape(meta_.xAxis)},${csvEscape(meta_.yAxis)}`);
 
-    for (let i = 0; i < result.labels.length; i++) {
-      lines.push(`${csvEscape(result.labels[i])},${result.values[i] || 0}`);
+    if (meta_.hasSeries && result.series?.length) {
+      // Multi-series: one column per series
+      const seriesNames = result.series.map(s => csvEscape(s.name));
+      lines.push(`${csvEscape(meta_.xAxis)},${seriesNames.join(',')}`);
+      for (let i = 0; i < result.labels.length; i++) {
+        const vals = result.series.map(s => s.values[i] || 0).join(',');
+        lines.push(`${csvEscape(result.labels[i])},${vals}`);
+      }
+    } else {
+      lines.push(`${csvEscape(meta_.xAxis)},${csvEscape(meta_.yAxis)}`);
+      for (let i = 0; i < result.labels.length; i++) {
+        lines.push(`${csvEscape(result.labels[i])},${result.values[i] || 0}`);
+      }
     }
+
     lines.push(`Total,${result.total || 0}`);
     lines.push('');
   }
@@ -276,13 +311,21 @@ async function generateExcel(data, meta) {
 
     // Table header
     const hRow = sheet.getRow(4);
-    hRow.values = [meta_.xAxis, meta_.yAxis];
+    if (meta_.hasSeries && result.series?.length) {
+      hRow.values = [meta_.xAxis, ...result.series.map(s => s.name)];
+    } else {
+      hRow.values = [meta_.xAxis, meta_.yAxis];
+    }
     hRow.eachCell(cell => Object.assign(cell, headerStyle));
 
     // Data rows
     for (let i = 0; i < result.labels.length; i++) {
       const r = sheet.getRow(5 + i);
-      r.values = [result.labels[i], result.values[i] || 0];
+      if (meta_.hasSeries && result.series?.length) {
+        r.values = [result.labels[i], ...result.series.map(s => s.values[i] || 0)];
+      } else {
+        r.values = [result.labels[i], result.values[i] || 0];
+      }
       r.eachCell(cell => { cell.border = cellBorder; });
     }
 
@@ -294,9 +337,10 @@ async function generateExcel(data, meta) {
       cell.border = cellBorder;
     });
 
+    const colCount = (meta_.hasSeries && result.series?.length) ? 1 + result.series.length : 2;
     sheet.columns = [
       { width: 35 },
-      { width: 18 },
+      ...Array(colCount - 1).fill({ width: 18 }),
     ];
   }
 

--- a/Backend/services/analytics-query.js
+++ b/Backend/services/analytics-query.js
@@ -432,6 +432,451 @@ async function consultationTrends(branch, startDate, endDate, options = {}) {
 }
 
 // ============================================================
+// DEMOGRAPHIC QUERY FUNCTIONS
+// ============================================================
+
+// Shared age-bracket CASE expression (institutional brackets used throughout)
+const AGE_BRACKET_EXPR = `
+  CASE
+    WHEN DATE_PART('year', AGE(up.date_of_birth)) < 17  THEN 'Under 17'
+    WHEN DATE_PART('year', AGE(up.date_of_birth)) <= 20 THEN '17–20'
+    WHEN DATE_PART('year', AGE(up.date_of_birth)) <= 25 THEN '21–25'
+    WHEN DATE_PART('year', AGE(up.date_of_birth)) <= 30 THEN '26–30'
+    WHEN DATE_PART('year', AGE(up.date_of_birth)) <= 40 THEN '31–40'
+    ELSE '41+'
+  END
+`;
+
+const AGE_BRACKET_ORDER = `
+  CASE age_group
+    WHEN 'Under 17' THEN 1
+    WHEN '17–20'    THEN 2
+    WHEN '21–25'    THEN 3
+    WHEN '26–30'    THEN 4
+    WHEN '31–40'    THEN 5
+    WHEN '41+'      THEN 6
+    ELSE 9
+  END
+`;
+
+// ── A. SEX DISTRIBUTION ──────────────────────────────────────
+
+/**
+ * Patient population by sex
+ */
+async function patientsBySex(branch, startDate, endDate) {
+  const bf = branchFilter(branch, 'up', 1);
+  const result = await db.query(`
+    SELECT up.sex, COUNT(DISTINCT p.id) as count
+    FROM "Patients" p
+    INNER JOIN "UsersPersonal" up ON p.id = up.id
+    WHERE up.date_of_birth IS NOT NULL ${bf.clause}
+    GROUP BY up.sex ORDER BY count DESC
+  `, [...bf.params]);
+
+  const labels = result.rows.map(r => r.sex || 'Unknown');
+  const values = result.rows.map(r => parseInt(r.count));
+  const total = values.reduce((sum, v) => sum + v, 0);
+  return { labels, values, total };
+}
+
+/**
+ * Consultation volume by patient sex
+ */
+async function consultationsBySex(branch, startDate, endDate) {
+  const bf = branchFilter(branch);
+  const result = await db.query(`
+    SELECT up.sex, COUNT(*) as count
+    FROM "Consultation" c
+    INNER JOIN "Patients" p ON c."patientId" = p.id
+    INNER JOIN "UsersPersonal" up ON p.id = up.id
+    WHERE c."createdAt" BETWEEN $1 AND $2 ${bf.clause}
+    GROUP BY up.sex ORDER BY count DESC
+  `, [startDate, endDate, ...bf.params]);
+
+  const labels = result.rows.map(r => r.sex || 'Unknown');
+  const values = result.rows.map(r => parseInt(r.count));
+  const total = values.reduce((sum, v) => sum + v, 0);
+  return { labels, values, total };
+}
+
+/**
+ * Top 5 diagnoses per sex — returns matrix data for grouped bar
+ * Shape: labels (diagnoses), series: [{ sex, values }]
+ */
+async function topDiagnosesBySex(branch, startDate, endDate) {
+  const bf = branchFilter(branch);
+
+  // First get top 5 diagnoses overall
+  const topResult = await db.query(`
+    SELECT COALESCE(icd.title, cd."diagnosisName") as diagnosis, COUNT(*) as total
+    FROM "ConsultationDiagnosis" cd
+    INNER JOIN "ConsultationOutcome" co ON cd."outcomeId" = co.id
+    INNER JOIN "Consultation" c ON co."consultationId" = c.id
+    INNER JOIN "Patients" p ON c."patientId" = p.id
+    INNER JOIN "UsersPersonal" up ON p.id = up.id
+    LEFT JOIN "ICDLookup" icd ON cd."icdId" = icd.id
+    WHERE co."recordedAt" BETWEEN $1 AND $2 ${bf.clause}
+    GROUP BY diagnosis ORDER BY total DESC LIMIT 5
+  `, [startDate, endDate, ...bf.params]);
+
+  const topLabels = topResult.rows.map(r => r.diagnosis);
+  if (topLabels.length === 0) return { labels: [], values: [], series: [], total: 0, chartVariant: 'grouped-bar' };
+
+  // Then get count per (diagnosis, sex) for those top 5
+  const bf2 = branchFilter(branch, 'up', topLabels.length + 3);
+  const placeholders = topLabels.map((_, i) => `$${i + 3}`).join(', ');
+  const matrixResult = await db.query(`
+    SELECT COALESCE(icd.title, cd."diagnosisName") as diagnosis,
+           up.sex, COUNT(*) as count
+    FROM "ConsultationDiagnosis" cd
+    INNER JOIN "ConsultationOutcome" co ON cd."outcomeId" = co.id
+    INNER JOIN "Consultation" c ON co."consultationId" = c.id
+    INNER JOIN "Patients" p ON c."patientId" = p.id
+    INNER JOIN "UsersPersonal" up ON p.id = up.id
+    LEFT JOIN "ICDLookup" icd ON cd."icdId" = icd.id
+    WHERE co."recordedAt" BETWEEN $1 AND $2
+      AND COALESCE(icd.title, cd."diagnosisName") IN (${placeholders})
+      ${bf2.clause}
+    GROUP BY diagnosis, up.sex
+  `, [startDate, endDate, ...topLabels, ...bf2.params]);
+
+  // Build series structure
+  const sexSet = [...new Set(matrixResult.rows.map(r => r.sex || 'Unknown'))].sort();
+  const matrixMap = {};
+  matrixResult.rows.forEach(r => {
+    const d = r.diagnosis;
+    const s = r.sex || 'Unknown';
+    if (!matrixMap[d]) matrixMap[d] = {};
+    matrixMap[d][s] = parseInt(r.count);
+  });
+
+  const series = sexSet.map(sex => ({
+    name: sex,
+    values: topLabels.map(label => matrixMap[label]?.[sex] || 0),
+  }));
+
+  const total = matrixResult.rows.reduce((sum, r) => sum + parseInt(r.count), 0);
+  return { labels: topLabels, values: series[0]?.values || [], series, total, chartVariant: 'grouped-bar' };
+}
+
+// ── B. AGE GROUP DISTRIBUTION ────────────────────────────────
+
+/**
+ * Patient population by institutional age bracket
+ */
+async function patientsByAgeGroup(branch, startDate, endDate) {
+  const bf = branchFilter(branch, 'up', 1);
+  const result = await db.query(`
+    SELECT (${AGE_BRACKET_EXPR}) as age_group, COUNT(DISTINCT p.id) as count
+    FROM "Patients" p
+    INNER JOIN "UsersPersonal" up ON p.id = up.id
+    WHERE up.date_of_birth IS NOT NULL ${bf.clause}
+    GROUP BY 1
+    ORDER BY ${AGE_BRACKET_ORDER}
+  `, [...bf.params]);
+
+  const labels = result.rows.map(r => r.age_group);
+  const values = result.rows.map(r => parseInt(r.count));
+  const total = values.reduce((sum, v) => sum + v, 0);
+  return { labels, values, total };
+}
+
+/**
+ * Consultation volume by patient age group
+ */
+async function consultationsByAgeGroup(branch, startDate, endDate) {
+  const bf = branchFilter(branch);
+  const result = await db.query(`
+    SELECT ${AGE_BRACKET_EXPR} as age_group, COUNT(*) as count
+    FROM "Consultation" c
+    INNER JOIN "Patients" p ON c."patientId" = p.id
+    INNER JOIN "UsersPersonal" up ON p.id = up.id
+    WHERE c."createdAt" BETWEEN $1 AND $2
+      AND up.date_of_birth IS NOT NULL
+      ${bf.clause}
+    GROUP BY 1
+    ORDER BY ${AGE_BRACKET_ORDER}
+  `, [startDate, endDate, ...bf.params]);
+
+  const labels = result.rows.map(r => r.age_group);
+  const values = result.rows.map(r => parseInt(r.count));
+  const total = values.reduce((sum, v) => sum + v, 0);
+  return { labels, values, total };
+}
+
+/**
+ * Average BMI per age group
+ */
+async function bmiByAgeGroup(branch, startDate, endDate) {
+  const bf = branchFilter(branch);
+  const result = await db.query(`
+    SELECT ${AGE_BRACKET_EXPR} as age_group,
+      ROUND(AVG(vs.weight_kg / POWER(vs.height_cm / 100, 2))::numeric, 2) as avg_bmi,
+      COUNT(*) as sample_count
+    FROM "VitalSigns" vs
+    INNER JOIN "Patients" p ON vs."patientId" = p.id
+    INNER JOIN "UsersPersonal" up ON p.id = up.id
+    WHERE vs.created_at BETWEEN $1 AND $2
+      AND vs.height_cm > 0 AND vs.weight_kg > 0
+      AND up.date_of_birth IS NOT NULL
+      ${bf.clause}
+    GROUP BY 1
+    ORDER BY ${AGE_BRACKET_ORDER}
+  `, [startDate, endDate, ...bf.params]);
+
+  const labels = result.rows.map(r => r.age_group);
+  const values = result.rows.map(r => parseFloat(r.avg_bmi));
+  const total = result.rows.reduce((sum, r) => sum + parseInt(r.sample_count), 0);
+  return { labels, values, total };
+}
+
+/**
+ * Top diagnoses by age group — matrix data (heatmap-ready)
+ * Shape: labels (age groups), series: [{ name: diagnosisName, values: [count per age group] }]
+ */
+async function diagnosesByAgeGroup(branch, startDate, endDate) {
+  const bf = branchFilter(branch);
+  const result = await db.query(`
+    SELECT ${AGE_BRACKET_EXPR} as age_group,
+           COALESCE(icd.title, cd."diagnosisName") as diagnosis,
+           COUNT(*) as count
+    FROM "ConsultationDiagnosis" cd
+    INNER JOIN "ConsultationOutcome" co ON cd."outcomeId" = co.id
+    INNER JOIN "Consultation" c ON co."consultationId" = c.id
+    INNER JOIN "Patients" p ON c."patientId" = p.id
+    INNER JOIN "UsersPersonal" up ON p.id = up.id
+    LEFT JOIN "ICDLookup" icd ON cd."icdId" = icd.id
+    WHERE co."recordedAt" BETWEEN $1 AND $2
+      AND up.date_of_birth IS NOT NULL
+      ${bf.clause}
+    GROUP BY 1, 2
+    ORDER BY ${AGE_BRACKET_ORDER}, count DESC
+  `, [startDate, endDate, ...bf.params]);
+
+  const ageGroups = ['Under 17', '17–20', '21–25', '26–30', '31–40', '41+'].filter(ag =>
+    result.rows.some(r => r.age_group === ag)
+  );
+
+  // Get top 8 diagnoses by total count across age groups for readability
+  const totalByDiagnosis = {};
+  result.rows.forEach(r => {
+    totalByDiagnosis[r.diagnosis] = (totalByDiagnosis[r.diagnosis] || 0) + parseInt(r.count);
+  });
+  const topDiagnoses = Object.entries(totalByDiagnosis)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 8)
+    .map(([name]) => name);
+
+  const matrixMap = {};
+  result.rows.forEach(r => {
+    if (!topDiagnoses.includes(r.diagnosis)) return;
+    if (!matrixMap[r.diagnosis]) matrixMap[r.diagnosis] = {};
+    matrixMap[r.diagnosis][r.age_group] = parseInt(r.count);
+  });
+
+  const series = topDiagnoses.map(name => ({
+    name,
+    values: ageGroups.map(ag => matrixMap[name]?.[ag] || 0),
+  }));
+
+  const total = result.rows.reduce((sum, r) => sum + parseInt(r.count), 0);
+  return { labels: ageGroups, values: series[0]?.values || [], series, total, chartVariant: 'heatmap' };
+}
+
+// ── C. DEPARTMENT / PROGRAM ──────────────────────────────────
+
+/**
+ * Employee consultation volume per department
+ */
+async function consultationsByDepartment(branch, startDate, endDate) {
+  const bf = branchFilter(branch);
+  const result = await db.query(`
+    WITH patient_dept AS (
+      SELECT DISTINCT ON (pul."patientId") pul."patientId", ep.department
+      FROM "patientUpdateLog" pul
+      INNER JOIN "profileRecord" pr ON pr.id = pul.id AND pr.profile_type = 'Employee'
+      INNER JOIN "employee_profile" ep ON ep."profileId" = pr.id
+      WHERE pul.status = 'Approved' AND ep.department IS NOT NULL
+      ORDER BY pul."patientId", pul.created_at DESC
+    )
+    SELECT pd.department, COUNT(*) as count
+    FROM "Consultation" c
+    INNER JOIN "Patients" p ON c."patientId" = p.id
+    INNER JOIN "UsersPersonal" up ON p.id = up.id
+    INNER JOIN patient_dept pd ON pd."patientId" = p.id
+    WHERE c."createdAt" BETWEEN $1 AND $2 ${bf.clause}
+    GROUP BY pd.department ORDER BY count DESC LIMIT 15
+  `, [startDate, endDate, ...bf.params]);
+
+  const labels = result.rows.map(r => r.department);
+  const values = result.rows.map(r => parseInt(r.count));
+  const total = values.reduce((sum, v) => sum + v, 0);
+  return { labels, values, total };
+}
+
+/**
+ * Student consultation volume per program
+ */
+async function consultationsByProgram(branch, startDate, endDate) {
+  const bf = branchFilter(branch);
+  const result = await db.query(`
+    WITH patient_prog AS (
+      SELECT DISTINCT ON (pul."patientId") pul."patientId", sp.program
+      FROM "patientUpdateLog" pul
+      INNER JOIN "profileRecord" pr ON pr.id = pul.id AND pr.profile_type = 'Student'
+      INNER JOIN "student_profile" sp ON sp."profileId" = pr.id
+      WHERE pul.status = 'Approved' AND sp.program IS NOT NULL
+      ORDER BY pul."patientId", pul.created_at DESC
+    )
+    SELECT pp.program, COUNT(*) as count
+    FROM "Consultation" c
+    INNER JOIN "Patients" p ON c."patientId" = p.id
+    INNER JOIN "UsersPersonal" up ON p.id = up.id
+    INNER JOIN patient_prog pp ON pp."patientId" = p.id
+    WHERE c."createdAt" BETWEEN $1 AND $2 ${bf.clause}
+    GROUP BY pp.program ORDER BY count DESC LIMIT 15
+  `, [startDate, endDate, ...bf.params]);
+
+  const labels = result.rows.map(r => r.program);
+  const values = result.rows.map(r => parseInt(r.count));
+  const total = values.reduce((sum, v) => sum + v, 0);
+  return { labels, values, total };
+}
+
+/**
+ * Lifestyle risk factors per department (employees)
+ * Returns series data: [{ name: 'Smokers', values: [count per dept] }, ...]
+ */
+async function lifestyleRisksByDepartment(branch, startDate, endDate) {
+  const bf = branchFilter(branch);
+  const result = await db.query(`
+    WITH patient_dept AS (
+      SELECT DISTINCT ON (pul."patientId") pul."patientId", ep.department
+      FROM "patientUpdateLog" pul
+      INNER JOIN "profileRecord" pr ON pr.id = pul.id AND pr.profile_type = 'Employee'
+      INNER JOIN "employee_profile" ep ON ep."profileId" = pr.id
+      WHERE pul.status = 'Approved' AND ep.department IS NOT NULL
+      ORDER BY pul."patientId", pul.created_at DESC
+    )
+    SELECT pd.department,
+      SUM(CASE WHEN l.smoker = true THEN 1 ELSE 0 END) as smokers,
+      SUM(CASE WHEN l."alcoholConsumer" = true THEN 1 ELSE 0 END) as alcohol,
+      SUM(CASE WHEN l."vapeUser" = true THEN 1 ELSE 0 END) as vape,
+      COUNT(*) as total_records
+    FROM "Lifestyle" l
+    INNER JOIN "patientUpdateLog" pul ON l.id = pul.id AND pul.status = 'Approved'
+    INNER JOIN "UsersPersonal" up ON pul."patientId" = up.id
+    INNER JOIN patient_dept pd ON pd."patientId" = pul."patientId"
+    WHERE pul.created_at BETWEEN $1 AND $2 ${bf.clause}
+    GROUP BY pd.department ORDER BY total_records DESC LIMIT 15
+  `, [startDate, endDate, ...bf.params]);
+
+  const labels = result.rows.map(r => r.department);
+  const series = [
+    { name: 'Smokers',   values: result.rows.map(r => parseInt(r.smokers)) },
+    { name: 'Alcohol',   values: result.rows.map(r => parseInt(r.alcohol)) },
+    { name: 'Vape Users', values: result.rows.map(r => parseInt(r.vape)) },
+  ];
+  const total = result.rows.reduce((sum, r) => sum + parseInt(r.total_records), 0);
+  return { labels, values: series[0].values, series, total, chartVariant: 'grouped-bar' };
+}
+
+// ── D. CROSS-DIMENSIONAL ─────────────────────────────────────
+
+/**
+ * Patient count matrix: sex × age group (heatmap)
+ * Shape: labels (age groups), series: [{ name: sex, values: [count per age group] }]
+ */
+async function sexAgeGroupMatrix(branch, startDate, endDate) {
+  const bf = branchFilter(branch, 'up', 1);
+  const result = await db.query(`
+    SELECT up.sex, (${AGE_BRACKET_EXPR}) as age_group, COUNT(DISTINCT p.id) as count
+    FROM "Patients" p
+    INNER JOIN "UsersPersonal" up ON p.id = up.id
+    WHERE up.date_of_birth IS NOT NULL ${bf.clause}
+    GROUP BY 1, 2
+    ORDER BY up.sex, ${AGE_BRACKET_ORDER}
+  `, [...bf.params]);
+
+  const ageGroups = ['Under 17', '17–20', '21–25', '26–30', '31–40', '41+'].filter(ag =>
+    result.rows.some(r => r.age_group === ag)
+  );
+  const sexes = [...new Set(result.rows.map(r => r.sex || 'Unknown'))].sort();
+
+  const matrixMap = {};
+  result.rows.forEach(r => {
+    const s = r.sex || 'Unknown';
+    if (!matrixMap[s]) matrixMap[s] = {};
+    matrixMap[s][r.age_group] = parseInt(r.count);
+  });
+
+  const series = sexes.map(sex => ({
+    name: sex,
+    values: ageGroups.map(ag => matrixMap[sex]?.[ag] || 0),
+  }));
+
+  const total = result.rows.reduce((sum, r) => sum + parseInt(r.count), 0);
+  return { labels: ageGroups, values: series[0]?.values || [], series, total, chartVariant: 'heatmap' };
+}
+
+/**
+ * Top diagnoses cross-tabulated by sex and age group
+ * Shape: labels (diagnoses), series: [{name: 'Male 17–20', values}, ...]
+ */
+async function diagnosesBySexAndAge(branch, startDate, endDate) {
+  const bf = branchFilter(branch);
+  const result = await db.query(`
+    SELECT COALESCE(icd.title, cd."diagnosisName") as diagnosis,
+           up.sex,
+           ${AGE_BRACKET_EXPR} as age_group,
+           COUNT(*) as count
+    FROM "ConsultationDiagnosis" cd
+    INNER JOIN "ConsultationOutcome" co ON cd."outcomeId" = co.id
+    INNER JOIN "Consultation" c ON co."consultationId" = c.id
+    INNER JOIN "Patients" p ON c."patientId" = p.id
+    INNER JOIN "UsersPersonal" up ON p.id = up.id
+    LEFT JOIN "ICDLookup" icd ON cd."icdId" = icd.id
+    WHERE co."recordedAt" BETWEEN $1 AND $2
+      AND up.date_of_birth IS NOT NULL
+      ${bf.clause}
+    GROUP BY 1, up.sex, 3
+    ORDER BY count DESC
+  `, [startDate, endDate, ...bf.params]);
+
+  // Get top 6 diagnoses
+  const totalByDiag = {};
+  result.rows.forEach(r => {
+    totalByDiag[r.diagnosis] = (totalByDiag[r.diagnosis] || 0) + parseInt(r.count);
+  });
+  const topDiagnoses = Object.entries(totalByDiag)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 6)
+    .map(([name]) => name);
+
+  // Build series: one per unique sex+ageGroup combination
+  const combinations = [...new Set(
+    result.rows.map(r => `${r.sex || 'Unknown'} ${r.age_group}`)
+  )].sort();
+
+  const matrixMap = {};
+  result.rows.forEach(r => {
+    if (!topDiagnoses.includes(r.diagnosis)) return;
+    const key = `${r.sex || 'Unknown'} ${r.age_group}`;
+    if (!matrixMap[key]) matrixMap[key] = {};
+    matrixMap[key][r.diagnosis] = parseInt(r.count);
+  });
+
+  const series = combinations.map(combo => ({
+    name: combo,
+    values: topDiagnoses.map(d => matrixMap[combo]?.[d] || 0),
+  })).filter(s => s.values.some(v => v > 0));
+
+  const total = result.rows.reduce((sum, r) => sum + parseInt(r.count), 0);
+  return { labels: topDiagnoses, values: series[0]?.values || [], series, total, chartVariant: 'heatmap' };
+}
+
+// ============================================================
 // QUERY REGISTRY - Register your queries here
 // ============================================================
 
@@ -499,6 +944,57 @@ const QUERY_HANDLERS = {
   'appointments-by-session': {
     handler: appointmentsBySession,
     description: 'Appointments grouped by session (Morning/Afternoon)',
+  },
+
+  // ── DEMOGRAPHICS ──────────────────────────────────────────
+
+  'patients-by-sex': {
+    handler: patientsBySex,
+    description: 'Patient population distribution by sex',
+  },
+  'consultations-by-sex': {
+    handler: consultationsBySex,
+    description: 'Consultation volume broken down by patient sex',
+  },
+  'top-diagnoses-by-sex': {
+    handler: topDiagnosesBySex,
+    description: 'Top diagnoses grouped by patient sex (grouped bar)',
+  },
+  'patients-by-age-group': {
+    handler: patientsByAgeGroup,
+    description: 'Patient population by institutional age brackets (17–20, 21–25, 26–30, 31–40, 41+)',
+  },
+  'consultations-by-age-group': {
+    handler: consultationsByAgeGroup,
+    description: 'Consultation demand by age group',
+  },
+  'bmi-by-age-group': {
+    handler: bmiByAgeGroup,
+    description: 'Average BMI per age group',
+  },
+  'diagnoses-by-age-group': {
+    handler: diagnosesByAgeGroup,
+    description: 'Top diagnoses per age group (heatmap-ready matrix data)',
+  },
+  'consultations-by-department': {
+    handler: consultationsByDepartment,
+    description: 'Employee consultation volume per department',
+  },
+  'consultations-by-program': {
+    handler: consultationsByProgram,
+    description: 'Student consultation volume per college/program',
+  },
+  'lifestyle-risks-by-department': {
+    handler: lifestyleRisksByDepartment,
+    description: 'Lifestyle risk factors (smoking, alcohol, vaping) per department',
+  },
+  'sex-age-group-matrix': {
+    handler: sexAgeGroupMatrix,
+    description: 'Patient count by sex × age group matrix (heatmap)',
+  },
+  'diagnoses-sex-age': {
+    handler: diagnosesBySexAndAge,
+    description: 'Top diagnoses cross-tabulated by sex and age group',
   },
 };
 

--- a/Backend/staff.js
+++ b/Backend/staff.js
@@ -20,7 +20,7 @@ const { initDashboardGraphQL } = require('./routes/dashboard/graphql.js');
 
 const consentRoutes = require('./routes/info/compliance/consent.js');
 const AnnouncementRoutes = require('./routes/info/announcement/announcement.js');
-const analyticsRoutes = require('./routes/documents/analytics/analytics.js');
+const analyticsRoutes = require('./routes/analytics/analytics.js');
 
 const loginRoutes = require('./routes/auth/user/login.js');
 const passwordResetRoutes = require('./routes/auth/email/emailpassword-reset.js');

--- a/mds-staff/src/modules/analytics/analytics-service.js
+++ b/mds-staff/src/modules/analytics/analytics-service.js
@@ -33,6 +33,15 @@ export const QUERY_CATEGORIES = {
     label: 'Lifestyle & Allergies',
     queries: ['lifestyle-risks', 'allergy-by-type', 'allergy-by-severity'],
   },
+  demographics: {
+    label: 'Demographics',
+    queries: [
+      'patients-by-sex', 'consultations-by-sex', 'top-diagnoses-by-sex',
+      'patients-by-age-group', 'consultations-by-age-group', 'bmi-by-age-group', 'diagnoses-by-age-group',
+      'consultations-by-department', 'consultations-by-program', 'lifestyle-risks-by-department',
+      'sex-age-group-matrix', 'diagnoses-sex-age',
+    ],
+  },
 };
 
 // ── Chart Type Recommendations ───────────────────────────────────────────────
@@ -53,6 +62,19 @@ export const CHART_TYPE_MAP = {
   'appointments-by-category': 'pie',
   'appointments-by-status': 'doughnut',
   'appointments-by-session': 'pie',
+  // Demographics
+  'patients-by-sex': 'bar',
+  'consultations-by-sex': 'bar',
+  'top-diagnoses-by-sex': 'grouped-bar',
+  'patients-by-age-group': 'bar',
+  'consultations-by-age-group': 'bar',
+  'bmi-by-age-group': 'bar',
+  'diagnoses-by-age-group': 'heatmap',
+  'consultations-by-department': 'bar',
+  'consultations-by-program': 'bar',
+  'lifestyle-risks-by-department': 'grouped-bar',
+  'sex-age-group-matrix': 'heatmap',
+  'diagnoses-sex-age': 'heatmap',
 };
 
 // ── Period Preset Options ────────────────────────────────────────────────────
@@ -194,13 +216,14 @@ export async function fetchMultipleQueries(dataTypes, branch, startDate, endDate
 
 /** Export presets mirror – used to populate presets in the UI without an API call */
 export const EXPORT_PRESETS = {
-  'full-report':    { label: 'Full Analytics Report',       description: 'All 15 analytics metrics combined' },
+  'full-report':    { label: 'Full Analytics Report',       description: 'All analytics metrics combined' },
   'consultations':  { label: 'Consultations Report',        description: 'Consultation metrics: type, status, trends' },
   'diagnoses':      { label: 'Diagnoses Report',            description: 'Diagnosis metrics: top ICD-10, type distribution' },
   'vitals':         { label: 'Vital Signs Report',          description: 'BMI and blood pressure trend analysis' },
   'appointments':   { label: 'Appointments Report',         description: 'Appointment category, status, and session data' },
   'clinical':       { label: 'Clinical Data Report',        description: 'Immunization coverage and dental procedures' },
   'lifestyle':      { label: 'Lifestyle & Allergies Report', description: 'Lifestyle risk factors and allergy data' },
+  'demographics':   { label: 'Demographics Report',         description: 'Sex, age group, department, and program analytics' },
 };
 
 /**

--- a/mds-staff/src/modules/analytics/components/analytics-chart-card.jsx
+++ b/mds-staff/src/modules/analytics/components/analytics-chart-card.jsx
@@ -1,5 +1,6 @@
 import React, { memo, useState, useCallback } from 'react';
 import { AnalyticsBarChart, AnalyticsLineChart, AnalyticsPieChart } from './analytics-charts';
+import AnalyticsHeatmap from './analytics-heatmap';
 import { CHART_TYPE_MAP, exportSingleMetric } from '../analytics-service';
 
 /**
@@ -82,6 +83,8 @@ const AnalyticsChartCard = memo(({ dataType, title, data, loading, error, dark, 
           <AnalyticsBarChart data={chartData} dark={dark} />
         ) : chartType === 'line' ? (
           <AnalyticsLineChart data={chartData} dark={dark} />
+        ) : chartType === 'heatmap' || chartType === 'grouped-bar' ? (
+          <AnalyticsHeatmap data={data?.data} />
         ) : (
           <AnalyticsPieChart data={chartData} isDoughnut={chartType === 'doughnut'} dark={dark} />
         )}

--- a/mds-staff/src/modules/analytics/components/analytics-heatmap.jsx
+++ b/mds-staff/src/modules/analytics/components/analytics-heatmap.jsx
@@ -1,0 +1,187 @@
+/**
+ * AnalyticsHeatmap
+ *
+ * Renders multi-series analytics data (e.g. sex × age group, diagnosis × age group)
+ * as a color-intensity heatmap table and supports `grouped-bar` fallback for
+ * smaller series counts.
+ *
+ * Props:
+ *   data     – { labels: string[], series: [{name, values}], total }
+ *   title    – optional chart title
+ *   variant  – 'heatmap' | 'grouped-bar' (default from data.chartVariant)
+ */
+import React, { useMemo } from 'react';
+
+// Tailwind-safe color palette (green intensity scale)
+const HEAT_COLORS = [
+  'bg-emerald-50 text-emerald-900',
+  'bg-emerald-100 text-emerald-900',
+  'bg-emerald-200 text-emerald-900',
+  'bg-emerald-300 text-emerald-900',
+  'bg-emerald-400 text-white',
+  'bg-emerald-500 text-white',
+  'bg-emerald-600 text-white',
+  'bg-emerald-700 text-white',
+  'bg-emerald-800 text-white',
+];
+
+// Colour palette for grouped-bar series (one colour per series)
+const BAR_COLORS = [
+  'bg-blue-500', 'bg-emerald-500', 'bg-amber-500',
+  'bg-rose-500', 'bg-purple-500', 'bg-cyan-500',
+  'bg-orange-500', 'bg-teal-500',
+];
+
+function clamp(v, min, max) {
+  return Math.min(Math.max(v, min), max);
+}
+
+// ──────────────────────────────────────────────────────────────
+// Heatmap
+// ──────────────────────────────────────────────────────────────
+function HeatmapTable({ labels, series }) {
+  const allValues = series.flatMap(s => s.values).filter(v => v > 0);
+  const maxVal = allValues.length > 0 ? Math.max(...allValues) : 1;
+
+  function heatClass(value) {
+    if (!value || value === 0) return 'bg-gray-50 text-gray-300';
+    const idx = clamp(Math.floor((value / maxVal) * (HEAT_COLORS.length - 1)), 0, HEAT_COLORS.length - 1);
+    return HEAT_COLORS[idx];
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-xs border-collapse">
+        <thead>
+          <tr>
+            {/* Empty corner cell */}
+            <th className="sticky left-0 bg-white px-2 py-1 text-left text-gray-500 font-medium border border-gray-200 min-w-[110px]">
+              Series \ Label
+            </th>
+            {labels.map((label) => (
+              <th
+                key={label}
+                className="px-2 py-1 text-center text-gray-600 font-medium border border-gray-200 whitespace-nowrap"
+              >
+                {label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {series.map((s) => (
+            <tr key={s.name}>
+              <td className="sticky left-0 bg-white px-2 py-1 font-medium text-gray-700 border border-gray-200 whitespace-nowrap">
+                {s.name}
+              </td>
+              {s.values.map((val, i) => (
+                <td
+                  key={i}
+                  className={`px-2 py-2 text-center border border-white font-medium transition-colors ${heatClass(val)}`}
+                  title={`${s.name} / ${labels[i]}: ${val}`}
+                >
+                  {val > 0 ? val.toLocaleString() : '–'}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {/* Legend */}
+      <div className="flex items-center gap-1 mt-2 px-1">
+        <span className="text-xs text-gray-400 mr-1">Low</span>
+        {HEAT_COLORS.map((cls, i) => (
+          <div key={i} className={`w-4 h-3 rounded-sm ${cls.split(' ')[0]}`} />
+        ))}
+        <span className="text-xs text-gray-400 ml-1">High</span>
+      </div>
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────
+// Grouped Bar chart (pure CSS, no recharts)
+// ──────────────────────────────────────────────────────────────
+function GroupedBarChart({ labels, series }) {
+  const maxVal = useMemo(() => {
+    const all = series.flatMap(s => s.values);
+    return all.length > 0 ? Math.max(...all) : 1;
+  }, [series]);
+
+  return (
+    <div className="space-y-3">
+      {/* Legend */}
+      <div className="flex flex-wrap gap-3 mb-2">
+        {series.map((s, i) => (
+          <div key={s.name} className="flex items-center gap-1.5">
+            <div className={`w-3 h-3 rounded-sm flex-shrink-0 ${BAR_COLORS[i % BAR_COLORS.length]}`} />
+            <span className="text-xs text-gray-600">{s.name}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* Grouped bars */}
+      <div className="overflow-x-auto">
+        <div className="flex items-end gap-3 min-w-max px-1 pb-1">
+          {labels.map((label, li) => (
+            <div key={label} className="flex flex-col items-center gap-1 min-w-[56px]">
+              {/* Group of bars */}
+              <div className="flex items-end gap-0.5 h-28">
+                {series.map((s, si) => {
+                  const pct = maxVal > 0 ? (s.values[li] / maxVal) * 100 : 0;
+                  return (
+                    <div
+                      key={s.name}
+                      className={`w-4 rounded-t-sm flex-shrink-0 ${BAR_COLORS[si % BAR_COLORS.length]} transition-all`}
+                      style={{ height: `${Math.max(pct, 2)}%` }}
+                      title={`${s.name}: ${s.values[li]?.toLocaleString()}`}
+                    />
+                  );
+                })}
+              </div>
+              {/* X-axis label */}
+              <span
+                className="text-[10px] text-gray-500 text-center leading-tight mt-0.5 max-w-[72px]"
+                style={{ wordBreak: 'break-word' }}
+              >
+                {label}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────
+// Main export
+// ──────────────────────────────────────────────────────────────
+export default function AnalyticsHeatmap({ data, title }) {
+  if (!data || !data.labels || !data.series || data.series.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-32 text-gray-400 text-sm">
+        No data available
+      </div>
+    );
+  }
+
+  const variant = data.chartVariant || 'heatmap';
+
+  return (
+    <div className="w-full">
+      {title && (
+        <p className="text-xs font-medium text-gray-500 mb-2">{title}</p>
+      )}
+      {variant === 'grouped-bar' ? (
+        <GroupedBarChart labels={data.labels} series={data.series} />
+      ) : (
+        <HeatmapTable labels={data.labels} series={data.series} />
+      )}
+      <p className="text-right text-xs text-gray-400 mt-1">
+        Total: {(data.total || 0).toLocaleString()}
+      </p>
+    </div>
+  );
+}

--- a/mds-staff/src/modules/analytics/staff-analytics.jsx
+++ b/mds-staff/src/modules/analytics/staff-analytics.jsx
@@ -29,11 +29,44 @@ const QUERY_LABELS = {
   'appointments-by-category': 'By Category',
   'appointments-by-status': 'By Status',
   'appointments-by-session': 'By Session',
+  // Demographics
+  'patients-by-sex': 'Patients by Sex',
+  'consultations-by-sex': 'Consultations by Sex',
+  'top-diagnoses-by-sex': 'Top Diagnoses by Sex',
+  'patients-by-age-group': 'Patients by Age Group',
+  'consultations-by-age-group': 'Consultations by Age Group',
+  'bmi-by-age-group': 'BMI by Age Group',
+  'diagnoses-by-age-group': 'Diagnoses by Age Group',
+  'consultations-by-department': 'Consultations by Department',
+  'consultations-by-program': 'Consultations by Program',
+  'lifestyle-risks-by-department': 'Lifestyle Risks by Department',
+  'sex-age-group-matrix': 'Sex × Age Group Matrix',
+  'diagnoses-sex-age': 'Diagnoses by Sex & Age',
 };
 
 // ── All query keys ───────────────────────────────────────────────────────────
 
 const ALL_QUERY_KEYS = Object.keys(CHART_TYPE_MAP);
+
+// ── Demographics dimension sub-filter ────────────────────────────────────────
+
+const DEMOGRAPHIC_DIMENSIONS = [
+  { key: 'all',        label: 'All' },
+  { key: 'sex',        label: 'Sex' },
+  { key: 'age',        label: 'Age Groups' },
+  { key: 'department', label: 'Department' },
+  { key: 'program',    label: 'Program' },
+  { key: 'matrix',     label: 'Cross-dimensional' },
+];
+
+const DEMOGRAPHIC_DIMENSION_QUERIES = {
+  all:        QUERY_CATEGORIES.demographics?.queries || [],
+  sex:        ['patients-by-sex', 'consultations-by-sex', 'top-diagnoses-by-sex'],
+  age:        ['patients-by-age-group', 'consultations-by-age-group', 'bmi-by-age-group', 'diagnoses-by-age-group'],
+  department: ['consultations-by-department', 'lifestyle-risks-by-department'],
+  program:    ['consultations-by-program'],
+  matrix:     ['sex-age-group-matrix', 'diagnoses-sex-age'],
+};
 
 /**
  * Staff Analytics View
@@ -46,6 +79,7 @@ const StaffAnalytics = () => {
   const [endDate, setEndDate] = useState(defaults.endDate);
   const [groupBy, setGroupBy] = useState('monthly');
   const [activeCategory, setActiveCategory] = useState('all');
+  const [demographicDimension, setDemographicDimension] = useState('all');
   const [results, setResults] = useState(new Map());
   const [loading, setLoading] = useState(false);
   const [initialLoad, setInitialLoad] = useState(true);
@@ -64,11 +98,14 @@ const StaffAnalytics = () => {
     return () => observer.disconnect();
   }, []);
 
-  // Get filtered query keys based on active category
+  // Get filtered query keys based on active category (+ demographic sub-filter)
   const visibleQueries = useMemo(() => {
     if (activeCategory === 'all') return ALL_QUERY_KEYS;
+    if (activeCategory === 'demographics') {
+      return DEMOGRAPHIC_DIMENSION_QUERIES[demographicDimension] || QUERY_CATEGORIES.demographics?.queries || [];
+    }
     return QUERY_CATEGORIES[activeCategory]?.queries || ALL_QUERY_KEYS;
-  }, [activeCategory]);
+  }, [activeCategory, demographicDimension]);
 
   // Fetch data
   const loadData = useCallback(async () => {
@@ -165,6 +202,26 @@ const StaffAnalytics = () => {
         onRefresh={loadData}
         loading={loading}
       />
+
+      {/* Demographics dimension sub-filter — only shown on Demographics tab */}
+      {activeCategory === 'demographics' && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="text-[10px] font-medium text-secondary-500 dark:text-neutral-400 mr-0.5">Dimension:</span>
+          {DEMOGRAPHIC_DIMENSIONS.map((dim) => (
+            <button
+              key={dim.key}
+              onClick={() => setDemographicDimension(dim.key)}
+              className={`px-2.5 py-0.5 text-[11px] font-medium rounded-full border transition-colors ${
+                demographicDimension === dim.key
+                  ? 'bg-emerald-500 border-emerald-500 text-white'
+                  : 'bg-white dark:bg-neutral-700 border-neutral-200 dark:border-neutral-600 text-secondary-500 dark:text-neutral-400 hover:border-emerald-400 hover:text-emerald-600'
+              }`}
+            >
+              {dim.label}
+            </button>
+          ))}
+        </div>
+      )}
 
       {/* Summary KPI Cards (only when 'all' category or initial view) */}
       {activeCategory === 'all' && (

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "MDSystem",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*",


### PR DESCRIPTION
- Add 12 demographic SQL query functions (patientsBySex, consultationsByAgeGroup, etc.)
- Implement sex × age group and diagnosis × demographic cross-tabulations
- Add AnalyticsHeatmap component for color-intensity matrix visualization
- Create Demographics category with dimension sub-filter (Sex, Age Groups, Department, Program, Cross-dimensional)
- Extend CSV/Excel export to handle multi-series data
- Support heatmap and grouped-bar chart types in analytics dashboard
- Refactor: move analytics routes from documents/ to top-level routes/analytics/